### PR TITLE
Add admin gold trustline initialization for XAUT

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,19 +1,95 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Env, Address};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol,
+};
 
 // Issue 2: Smart Contract - Stellar Path Payments & Yield Allocation (Blend Integration)
 
 #[contracttype]
 pub enum DataKey {
+    Admin,
     UserBalance(Address),
     TotalDeposits,
+    GoldAssetCode,
+    GoldAssetIssuer,
+    GoldTrustlineReady,
+    GoldTrustlineReserveStroops,
 }
+
+const CANONICAL_GOLD_ASSET_CODE: Symbol = symbol_short!("XAUT");
+const CANONICAL_GOLD_ASSET_ISSUER: &str = "GCRLXTLD7XIRXWXV2PDCC74O5TUUKN3OODJAM6TWVE4AIRNMGQJK3KWQ";
+const TRUSTLINE_BASE_RESERVE_STROOPS: i128 = 5_000_000;
 
 #[contract]
 pub struct SmasageYieldRouter;
 
 #[contractimpl]
 impl SmasageYieldRouter {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn init_gold_trustline(env: Env, admin: Address, reserve_stroops: i128) {
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
+
+        assert!(admin == stored_admin, "Only admin can initialize Gold trustline");
+        admin.require_auth();
+        assert!(
+            reserve_stroops >= TRUSTLINE_BASE_RESERVE_STROOPS,
+            "Insufficient base reserve for trustline"
+        );
+
+        let gold_issuer = String::from_str(&env, CANONICAL_GOLD_ASSET_ISSUER);
+        env.storage()
+            .persistent()
+            .set(&DataKey::GoldAssetCode, &CANONICAL_GOLD_ASSET_CODE);
+        env.storage()
+            .persistent()
+            .set(&DataKey::GoldAssetIssuer, &gold_issuer);
+        env.storage()
+            .persistent()
+            .set(&DataKey::GoldTrustlineReserveStroops, &reserve_stroops);
+        env.storage()
+            .persistent()
+            .set(&DataKey::GoldTrustlineReady, &true);
+    }
+
+    pub fn get_gold_asset(env: Env) -> (Symbol, String) {
+        let code = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GoldAssetCode)
+            .unwrap_or(CANONICAL_GOLD_ASSET_CODE);
+        let issuer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GoldAssetIssuer)
+            .unwrap_or(String::from_str(&env, CANONICAL_GOLD_ASSET_ISSUER));
+        (code, issuer)
+    }
+
+    pub fn is_gold_trustline_ready(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::GoldTrustlineReady)
+            .unwrap_or(false)
+    }
+
+    pub fn get_gold_reserve_stroops(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::GoldTrustlineReserveStroops)
+            .unwrap_or(0)
+    }
+
     /// Initialize the contract and accept deposits in USDC.
     /// In a real implementation, this would handle token transfers and issue calls to the Blend Protocol.
     pub fn deposit(env: Env, from: Address, amount: i128, blend_percentage: u32, lp_percentage: u32) {
@@ -47,7 +123,30 @@ impl SmasageYieldRouter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env};
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    #[test]
+    fn test_initialize_gold_trustline() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let client = SmasageYieldRouterClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+
+        env.mock_all_auths();
+
+        client.initialize(&admin);
+        client.init_gold_trustline(&admin, &5_000_000);
+
+        let (asset_code, asset_issuer) = client.get_gold_asset();
+        assert_eq!(asset_code, symbol_short!("XAUT"));
+        assert_eq!(
+            asset_issuer,
+            String::from_str(&env, "GCRLXTLD7XIRXWXV2PDCC74O5TUUKN3OODJAM6TWVE4AIRNMGQJK3KWQ")
+        );
+        assert!(client.is_gold_trustline_ready());
+        assert_eq!(client.get_gold_reserve_stroops(), 5_000_000);
+    }
 
     #[test]
     fn test_deposit_withdraw() {
@@ -56,8 +155,11 @@ mod test {
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
 
         let user = Address::generate(&env);
+        let admin = Address::generate(&env);
         
         env.mock_all_auths();
+
+        client.initialize(&admin);
 
         // 60% Blend, 30% LP, 10% Gold (mocked conceptually)
         client.deposit(&user, &1000, &60, &30);

--- a/contracts/test_snapshots/test/test_deposit_withdraw.1.json
+++ b/contracts/test_snapshots/test/test_deposit_withdraw.1.json
@@ -1,10 +1,29 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -74,6 +93,45 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
       [
         {
           "contract_data": {
@@ -160,7 +218,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 801925984706572462
+                "nonce": 1033654523790656264
               }
             },
             "durability": "temporary"
@@ -175,7 +233,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 801925984706572462
+                    "nonce": 1033654523790656264
                   }
                 },
                 "durability": "temporary",
@@ -209,6 +267,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
                   }
                 },
                 "durability": "temporary",


### PR DESCRIPTION
closes #9 

This PR introduces contract initialization with an admin account, then adds a dedicated function to initialize Gold trustline metadata using the canonical asset configured as XAUT with issuer GCRLXTLD7XIRXWXV2PDCC74O5TUUKN3OODJAM6TWVE4AIRNMGQJK3KWQ. The trustline setup function requires admin authorization and enforces a minimum base reserve of 5,000,000 stroops before marking the trustline as ready.

Changes included:

Added initialize(env, admin) to set contract admin once
Added init_gold_trustline(env, admin, reserve_stroops) with:
admin-only access
base reserve validation
persistent storage of Gold asset code, issuer, reserve amount, and ready flag
Added read helpers:
get_gold_asset()
is_gold_trustline_ready()
get_gold_reserve_stroops()
Added/updated tests to validate the full initialization flow and existing deposit/withdraw behavior
Validation:

cargo test passes (2 passed, 0 failed)
Acceptance criteria coverage:

Contract is authorized through explicit admin-gated Gold trustline initialization state
Submitting the initialization transaction creates/updates persistent ledger entries for Gold trustline state and reserve tracking