### PR TITLE
feat: extract PortfolioStats, remove dynamic styles, centralise config, add WS indicator

### DIFF
--- a/frontend/src/app/components/DashboardHeader.tsx
+++ b/frontend/src/app/components/DashboardHeader.tsx
@@ -1,8 +1,29 @@
 import React from 'react';
+import { WsStatusIndicator } from './WsStatusIndicator';
 
-export const DashboardHeader: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
-  <header className="dashboard-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '1rem 2rem', borderBottom: '1px solid #eee' }}>
-    <div style={{ fontWeight: 700, fontSize: '1.5rem' }}>Smasage</div>
+interface DashboardHeaderProps {
+  children?: React.ReactNode;
+  wsConnected?: boolean;
+}
+
+export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ children, wsConnected = false }) => (
+  <header
+    className="dashboard-header"
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: '1rem 2rem',
+      borderBottom: '1px solid #eee',
+    }}
+  >
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <span style={{ fontWeight: 700, fontSize: '1.5rem' }}>Smasage</span>
+      <WsStatusIndicator connected={wsConnected} />
+      <span style={{ fontSize: '0.75rem', color: wsConnected ? '#10b981' : '#f59e0b' }}>
+        {wsConnected ? 'Live' : 'Connecting…'}
+      </span>
+    </div>
     <div>{children}</div>
   </header>
 );

--- a/frontend/src/app/components/PortfolioStats.tsx
+++ b/frontend/src/app/components/PortfolioStats.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+import { Wallet, TrendingUp } from 'lucide-react';
+
+export interface PortfolioStatsProps {
+  totalValue: number;
+  apy: number;
+  valueChange: number;
+}
+
+export const PortfolioStats: React.FC<PortfolioStatsProps> = ({
+  totalValue,
+  apy,
+  valueChange,
+}) => {
+  const formattedValue = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(totalValue);
+
+  const changeLabel = `${valueChange >= 0 ? '+' : ''}${valueChange.toFixed(1)}%`;
+
+  return (
+    <div className="stats-grid">
+      <div className="stat-card">
+        <div className="stat-label">
+          <Wallet size={16} color="var(--accent-primary)" />
+          Total Value
+        </div>
+        <div className="stat-value">
+          {formattedValue}
+          <span className="stat-sub">{changeLabel}</span>
+        </div>
+      </div>
+
+      <div className="stat-card secondary">
+        <div className="stat-label">
+          <TrendingUp size={16} color="var(--accent-secondary)" />
+          Est. Monthly APY
+        </div>
+        <div className="stat-value">
+          {apy.toFixed(1)}%
+          <span className="stat-sub">Active</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/app/components/WsStatusIndicator.tsx
+++ b/frontend/src/app/components/WsStatusIndicator.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+
+interface WsStatusIndicatorProps {
+  connected: boolean;
+}
+
+export const WsStatusIndicator: React.FC<WsStatusIndicatorProps> = ({ connected }) => (
+  <span
+    title={connected ? 'Live — WebSocket connected' : 'Connecting…'}
+    aria-label={connected ? 'WebSocket connected' : 'WebSocket connecting'}
+    style={{
+      display: 'inline-block',
+      width: 8,
+      height: 8,
+      borderRadius: '50%',
+      flexShrink: 0,
+      backgroundColor: connected ? '#10b981' : '#f59e0b',
+      boxShadow: connected
+        ? '0 0 0 2px rgba(16,185,129,0.25)'
+        : '0 0 0 2px rgba(245,158,11,0.25)',
+      animation: connected ? 'ws-pulse 2s ease-in-out infinite' : 'ws-blink 1.2s step-start infinite',
+    }}
+  />
+);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -701,3 +701,52 @@ h2 {
   color: #3b82f6;
   border: 1px solid rgba(59, 130, 246, 0.3);
 }
+/* ── Freighter install modal (Issue #36) ─────────────────────── */
+.modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #18181b;
+  color: #fff;
+  padding: 2rem 2.5rem;
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  text-align: center;
+  min-width: 320px;
+}
+
+.install-link {
+  display: inline-block;
+  margin: 1rem 0;
+  color: #8b5cf6;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.close-modal {
+  background: #27272a;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-top: 1rem;
+}
+
+/* ── WS status indicator animations (Issue #48) ─────────────── */
+@keyframes ws-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.25); }
+  50%       { box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.12); }
+}
+
+@keyframes ws-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useState, useEffect, useRef } from 'react';
-import { Bot, Send, Wallet, TrendingUp, Target, Activity, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Bot, Send, Target, Activity, CheckCircle2, AlertCircle } from 'lucide-react';
+import { PortfolioStats } from './components/PortfolioStats';
 import { evaluateGoalStatus, formatCurrency, getStatusColor, type GoalData } from '../utils/goalProjection';
 import PortfolioChart from './PortfolioChart';
 import { parseAllocationsFromMessage, getDefaultAllocations } from '../utils/allocationParser';
@@ -138,53 +139,9 @@ export default function Home() {
     }, 1800);
   };
 
-  const modalStyles = `
-  .modal-overlay {
-    position: fixed;
-    top: 0; left: 0; right: 0; bottom: 0;
-    background: rgba(0,0,0,0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-  }
-  .modal-content {
-    background: #18181b;
-    color: #fff;
-    padding: 2rem 2.5rem;
-    border-radius: 16px;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.25);
-    text-align: center;
-    min-width: 320px;
-  }
-  .install-link {
-    display: inline-block;
-    margin: 1rem 0;
-    color: #8b5cf6;
-    font-weight: 600;
-    text-decoration: underline;
-  }
-  .close-modal {
-    background: #27272a;
-    color: #fff;
-    border: none;
-    padding: 0.5rem 1.5rem;
-    border-radius: 8px;
-    cursor: pointer;
-    margin-top: 1rem;
-  }
-  `;
-
-  if (typeof window !== 'undefined' && !document.getElementById('modal-styles')) {
-    const style = document.createElement('style');
-    style.id = 'modal-styles';
-    style.innerHTML = modalStyles;
-    document.head.appendChild(style);
-  }
-
   return (
     <>
-      <DashboardHeader>
+      <DashboardHeader wsConnected={wsConnected}>
         <ConnectWalletButton onClick={handleConnectWallet} publicKey={publicKey || undefined} />
       </DashboardHeader>
       {showInstallModal && (
@@ -205,28 +162,11 @@ export default function Home() {
           Real-time on-chain tracking • Stellar Mainnet 🚀
         </p>
 
-        <div className="stats-grid">
-          <div className="stat-card">
-            <div className="stat-label">
-              <Wallet size={16} color="var(--accent-primary)" />
-              Total Value
-            </div>
-            <div className="stat-value">
-              $12,450
-              <span className="stat-sub">+12.4%</span>
-            </div>
-          </div>
-          <div className="stat-card secondary">
-            <div className="stat-label">
-              <TrendingUp size={16} color="var(--accent-secondary)" />
-              Est. Monthly APY
-            </div>
-            <div className="stat-value">
-              8.5%
-              <span className="stat-sub">Active</span>
-            </div>
-          </div>
-        </div>
+        <PortfolioStats
+          totalValue={goalData.currentBalance}
+          apy={goalData.expectedAPY}
+          valueChange={12.4}
+        />
 
         <div className="goal-section">
           <div className="goal-header">

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,0 +1,14 @@
+// WebSocket
+export const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:3001';
+
+// Currency formatting
+export const CURRENCY_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+};
+
+// Notification / reconnect
+export const WS_MAX_RECONNECT_ATTEMPTS = 5;
+export const WS_MAX_RECONNECT_DELAY_MS = 30_000;

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useCallback, useRef } from 'react';
+import { WS_URL, WS_MAX_RECONNECT_ATTEMPTS, WS_MAX_RECONNECT_DELAY_MS } from '../config/constants';
 
 export interface IncomingNotification {
   type: 'connected' | 'notification' | 'agent-message' | 'pong';
@@ -24,15 +25,13 @@ export function useNotifications(options: UseNotificationsOptions) {
   const { userId, onNotification, onError, enabled = true } = options;
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptsRef = useRef(0);
-  const maxReconnectAttempts = 5;
+  const maxReconnectAttempts = WS_MAX_RECONNECT_ATTEMPTS;
 
   const connect = useCallback(() => {
     if (!enabled || !userId) return;
 
     try {
-      const wsUrl = `${
-        process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:3001'
-      }?userId=${encodeURIComponent(userId)}`;
+      const wsUrl = `${WS_URL}?userId=${encodeURIComponent(userId)}`;
 
       console.log('[WS] Connecting to:', wsUrl);
       const ws = new WebSocket(wsUrl);
@@ -73,7 +72,7 @@ export function useNotifications(options: UseNotificationsOptions) {
 
         // Attempt reconnection with exponential backoff
         if (reconnectAttemptsRef.current < maxReconnectAttempts) {
-          const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 30000);
+          const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), WS_MAX_RECONNECT_DELAY_MS);
           reconnectAttemptsRef.current++;
           console.log(`[WS] Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current})`);
           setTimeout(connect, delay);


### PR DESCRIPTION
Closes #28
Closes #36
Closes #46
Closes #48

## What changed

### #28 — Extract PortfolioStats component
- New `components/PortfolioStats.tsx` with strict TypeScript props (`totalValue`, `apy`, `valueChange`)
- Renders the `stats-grid` / `stat-card` JSX; visual appearance unchanged
- `page.tsx` replaced the inline stats block with `<PortfolioStats />`

### #36 — Remove dynamic style injection
- Deleted `modalStyles` string and `document.createElement('style')` block from `page.tsx`
- Moved `.modal-overlay`, `.modal-content`, `.install-link`, `.close-modal` into `globals.css`

### #46 — Centralise app configuration
- Created `src/config/constants.ts` with `WS_URL`, `CURRENCY_FORMAT_OPTIONS`, `WS_MAX_RECONNECT_ATTEMPTS`, `WS_MAX_RECONNECT_DELAY_MS`
- `useNotifications.ts` now imports all config values from `constants.ts`; hardcoded strings removed

### #48 — WebSocket connection status UI
- New `components/WsStatusIndicator.tsx`: 8 px dot, green (#10b981) + pulse when connected, amber (#f59e0b) + blink when disconnected; `title` attribute for accessibility
- `DashboardHeader` accepts `wsConnected` prop and renders the indicator with a "Live" / "Connecting…" label
- `page.tsx` passes `wsConnected` state to `DashboardHeader`
- CSS keyframes (`ws-pulse`, `ws-blink`) added to `globals.css`