### PR TITLE
feat: add strict FreighterApi window types and remove (window as any) casts

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -24,12 +24,12 @@ export default function Home() {
   const [showInstallModal, setShowInstallModal] = useState(false);
     // Connect Wallet logic
     const handleConnectWallet = async () => {
-      if (!(window as any).freighterApi) {
+      if (!window.freighterApi) {
         setShowInstallModal(true);
         return;
       }
       try {
-        const key = await (window as any).freighterApi.getPublicKey();
+        const key = await window.freighterApi.getPublicKey();
         setPublicKey(key);
       } catch (e) {
         // Optionally handle rejection

--- a/frontend/src/types/freighter.d.ts
+++ b/frontend/src/types/freighter.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Type definitions for the Freighter browser wallet extension.
+ * Extends the global Window interface so freighterApi can be accessed
+ * without casting to `any`.
+ *
+ * Reference: https://docs.freighter.app/docs/ref/freighter-api
+ */
+
+export interface FreighterApi {
+  /** Returns the user's public key if the wallet is connected and unlocked. */
+  getPublicKey(): Promise<string>;
+
+  /** Returns true when Freighter is installed and the user has granted access. */
+  isConnected(): Promise<boolean>;
+
+  /**
+   * Signs an XDR-encoded transaction and returns the signed XDR string.
+   * @param xdr     - Base64-encoded transaction XDR.
+   * @param network - Stellar network passphrase (e.g. "Test SDF Network ; September 2015").
+   */
+  signTransaction(xdr: string, network?: string): Promise<string>;
+
+  /**
+   * Signs an arbitrary message and returns a base64-encoded signature.
+   * @param message - UTF-8 message to sign.
+   */
+  signMessage?(message: string): Promise<string>;
+
+  /** Returns the network the wallet is currently set to. */
+  getNetwork?(): Promise<string>;
+
+  /** Returns the network passphrase for the current network. */
+  getNetworkDetails?(): Promise<{ network: string; networkPassphrase: string }>;
+}
+
+declare global {
+  interface Window {
+    freighterApi?: FreighterApi;
+  }
+}


### PR DESCRIPTION
Closes #44

## What changed

- Created `frontend/src/types/freighter.d.ts` — extends the global `Window` interface with a typed `FreighterApi` shape covering `getPublicKey()`, `isConnected()`, `signTransaction()`, and optional `signMessage()`, `getNetwork()`, `getNetworkDetails()`
- Replaced both `(window as any).freighterApi` casts in `page.tsx` with plain `window.freighterApi` — TypeScript now resolves the type through the global declaration
- No `tsconfig.json` changes needed — the existing `**/*.ts` include glob picks up the new file automatically

## How to test
- Run `tsc --noEmit` in the `frontend` directory — should compile with zero errors
- Search the codebase for `window as any` — should return no results