### PR TITLE
feat(types): resolve issue #45 - strict WebSocket payload types

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,6 +21,10 @@ import {
 } from "../utils/allocationParser";
 import type { AssetAllocation } from "../utils/chartUtils";
 import { useNotifications } from "../hooks/useNotifications";
+import {
+  isAgentMessageNotification,
+  isConnectedNotification,
+} from "../types/websocket";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { ConnectWalletButton } from "./components/ConnectWalletButton";
 import { useFreighter } from "../hooks/useFreighter";
@@ -89,23 +93,24 @@ export default function Home() {
   const { registerGoal } = useNotifications({
     userId: "user-demo-001",
     onNotification: (notification) => {
-      if (notification.type === "connected") {
+      if (isConnectedNotification(notification)) {
         console.log("[App] Connected to notification server");
         setWsConnected(true);
         setIsLoading(false);
-      } else if (notification.type === "agent-message") {
-        const payload = notification.payload as { text: string; proactive?: boolean; timestamp?: string };
+      } else if (isAgentMessageNotification(notification)) {
+        // payload is fully typed as AgentMessagePayload — no cast needed
+        const { text, proactive, timestamp } = notification.payload;
         const agentMsg: Message = {
           id: Date.now(),
           sender: "agent",
-          text: payload.text,
-          proactive: payload.proactive,
-          timestamp: payload.timestamp,
+          text,
+          proactive,
+          timestamp,
         };
         setMessages((prev) => [...prev, agentMsg]);
 
         // Parse allocations if present
-        const parsedAllocations = parseAllocationsFromMessage(payload.text);
+        const parsedAllocations = parseAllocationsFromMessage(text);
         if (parsedAllocations) {
           setAllocations(parsedAllocations);
         }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -4,15 +4,16 @@
  * Handles receiving and processing proactive messages
  */
 
-import { useEffect, useCallback, useRef } from 'react';
-import { WS_URL, WS_MAX_RECONNECT_ATTEMPTS, WS_MAX_RECONNECT_DELAY_MS } from '../config/constants';
+import { useEffect, useCallback, useRef, useState } from "react";
+import {
+  WS_URL,
+  WS_MAX_RECONNECT_ATTEMPTS,
+  WS_MAX_RECONNECT_DELAY_MS,
+} from "../config/constants";
+import type { IncomingNotification, GoalPayload } from "../types/websocket";
 
-export interface IncomingNotification {
-  type: 'connected' | 'notification' | 'agent-message' | 'pong';
-  userId?: string;
-  payload?: unknown;
-  timestamp?: string;
-}
+// Re-export so existing imports from this module continue to work.
+export type { IncomingNotification } from "../types/websocket";
 
 interface UseNotificationsOptions {
   userId: string;
@@ -26,6 +27,10 @@ export function useNotifications(options: UseNotificationsOptions) {
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const maxReconnectAttempts = WS_MAX_RECONNECT_ATTEMPTS;
+  // Holds the latest connect function so ws.onclose can schedule a reconnect
+  // without closing over a stale reference or creating a circular declaration.
+  const connectRef = useRef<() => void>(() => undefined);
+  const [isConnected, setIsConnected] = useState(false);
 
   const connect = useCallback(() => {
     if (!enabled || !userId) return;
@@ -33,58 +38,70 @@ export function useNotifications(options: UseNotificationsOptions) {
     try {
       const wsUrl = `${WS_URL}?userId=${encodeURIComponent(userId)}`;
 
-      console.log('[WS] Connecting to:', wsUrl);
+      console.log("[WS] Connecting to:", wsUrl);
       const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {
-        console.log('[WS] Connected');
+        console.log("[WS] Connected");
         reconnectAttemptsRef.current = 0;
+        setIsConnected(true);
 
         // Send initial registration
         ws.send(
           JSON.stringify({
-            type: 'ping',
+            type: "ping",
             timestamp: new Date().toISOString(),
-          })
+          }),
         );
       };
 
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data) as IncomingNotification;
-          console.log('[WS] Received:', data.type, data);
+          console.log("[WS] Received:", data.type, data);
 
           onNotification?.(data);
         } catch (error) {
-          console.error('[WS] Error parsing message:', error);
+          console.error("[WS] Error parsing message:", error);
         }
       };
 
       ws.onerror = (event) => {
-        const error = new Error('WebSocket error');
-        console.error('[WS] Error:', error, event);
+        const error = new Error("WebSocket error");
+        console.error("[WS] Error:", error, event);
         onError?.(error);
       };
 
       ws.onclose = () => {
-        console.log('[WS] Disconnected');
+        console.log("[WS] Disconnected");
         wsRef.current = null;
+        setIsConnected(false);
 
         // Attempt reconnection with exponential backoff
         if (reconnectAttemptsRef.current < maxReconnectAttempts) {
-          const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), WS_MAX_RECONNECT_DELAY_MS);
+          const delay = Math.min(
+            1000 * Math.pow(2, reconnectAttemptsRef.current),
+            WS_MAX_RECONNECT_DELAY_MS,
+          );
           reconnectAttemptsRef.current++;
-          console.log(`[WS] Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current})`);
-          setTimeout(connect, delay);
+          console.log(
+            `[WS] Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current})`,
+          );
+          setTimeout(() => connectRef.current(), delay);
         }
       };
 
       wsRef.current = ws;
     } catch (error) {
-      console.error('[WS] Connection error:', error);
+      console.error("[WS] Connection error:", error);
       onError?.(error instanceof Error ? error : new Error(String(error)));
     }
-  }, [userId, onNotification, onError, enabled]);
+  }, [userId, onNotification, onError, enabled, maxReconnectAttempts]);
+
+  // Keep the ref in sync so onclose always calls the latest version.
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
 
   const disconnect = useCallback(() => {
     if (wsRef.current) {
@@ -93,35 +110,32 @@ export function useNotifications(options: UseNotificationsOptions) {
     }
   }, []);
 
-  const sendMessage = useCallback(
-    (message: Record<string, unknown>) => {
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify(message));
-      } else {
-        console.warn('[WS] WebSocket not open, message not sent:', message);
-      }
-    },
-    []
-  );
+  const sendMessage = useCallback((message: Record<string, unknown>) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(message));
+    } else {
+      console.warn("[WS] WebSocket not open, message not sent:", message);
+    }
+  }, []);
 
   const registerGoal = useCallback(
-    (goal: Record<string, unknown>) => {
+    (goal: GoalPayload) => {
       sendMessage({
-        type: 'register-goal',
+        type: "register-goal",
         payload: goal,
       });
     },
-    [sendMessage]
+    [sendMessage],
   );
 
   const updateGoal = useCallback(
-    (goal: Record<string, unknown>) => {
+    (goal: GoalPayload) => {
       sendMessage({
-        type: 'update-goal',
+        type: "update-goal",
         payload: goal,
       });
     },
-    [sendMessage]
+    [sendMessage],
   );
 
   useEffect(() => {
@@ -130,7 +144,7 @@ export function useNotifications(options: UseNotificationsOptions) {
   }, [connect, disconnect]);
 
   return {
-    isConnected: wsRef.current?.readyState === WebSocket.OPEN,
+    isConnected,
     sendMessage,
     registerGoal,
     updateGoal,

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -1,0 +1,136 @@
+/**
+ * WebSocket Payload Types – Issue #45
+ *
+ * Defines strict interfaces for every WebSocket message payload and provides
+ * type guard helpers so callers can safely narrow `notification.payload`
+ * without using `as any` or unsafe casts.
+ */
+
+// ---------------------------------------------------------------------------
+// Outgoing message payloads (client → server)
+// ---------------------------------------------------------------------------
+
+/** Shape of a goal object sent to the server when registering or updating. */
+export interface GoalPayload {
+  currentBalance: number;
+  targetAmount: number;
+  targetDate: string;
+  monthlyContribution: number;
+  expectedAPY: number;
+}
+
+/** Wrapper for register-goal messages. */
+export interface RegisterGoalMessage {
+  type: 'register-goal';
+  payload: GoalPayload;
+}
+
+/** Wrapper for update-goal messages. */
+export interface UpdateGoalMessage {
+  type: 'update-goal';
+  payload: GoalPayload;
+}
+
+/** Wrapper for ping messages. */
+export interface PingMessage {
+  type: 'ping';
+  timestamp: string;
+}
+
+/** Union of all outgoing message types. */
+export type OutgoingWsMessage = RegisterGoalMessage | UpdateGoalMessage | PingMessage;
+
+// ---------------------------------------------------------------------------
+// Incoming payload shapes (server → client)
+// ---------------------------------------------------------------------------
+
+/** Payload for `agent-message` notifications. */
+export interface AgentMessagePayload {
+  text: string;
+  proactive?: boolean;
+  timestamp?: string;
+}
+
+/** Payload for `goal-update` notifications (server-pushed goal status). */
+export interface GoalUpdatePayload {
+  currentBalance: number;
+  targetAmount: number;
+  progressPercentage: number;
+  status: 'on-track' | 'ahead' | 'falling-behind';
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union of all incoming notifications
+// ---------------------------------------------------------------------------
+
+interface ConnectedNotification {
+  type: 'connected';
+  userId?: string;
+  payload?: undefined;
+  timestamp?: string;
+}
+
+interface AgentMessageNotification {
+  type: 'agent-message';
+  userId?: string;
+  payload: AgentMessagePayload;
+  timestamp?: string;
+}
+
+interface GoalUpdateNotification {
+  type: 'goal-update';
+  userId?: string;
+  payload: GoalUpdatePayload;
+  timestamp?: string;
+}
+
+interface PongNotification {
+  type: 'pong';
+  userId?: string;
+  payload?: undefined;
+  timestamp?: string;
+}
+
+/** Generic notification – used as the catch-all / unknown type. */
+interface GenericNotification {
+  type: 'notification';
+  userId?: string;
+  payload?: unknown;
+  timestamp?: string;
+}
+
+/**
+ * Discriminated union covering every notification type the server can send.
+ * Add new variants here as the API evolves.
+ */
+export type IncomingNotification =
+  | ConnectedNotification
+  | AgentMessageNotification
+  | GoalUpdateNotification
+  | PongNotification
+  | GenericNotification;
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/** Narrows a notification to `AgentMessageNotification`. */
+export function isAgentMessageNotification(
+  n: IncomingNotification
+): n is AgentMessageNotification {
+  return n.type === 'agent-message';
+}
+
+/** Narrows a notification to `GoalUpdateNotification`. */
+export function isGoalUpdateNotification(
+  n: IncomingNotification
+): n is GoalUpdateNotification {
+  return n.type === 'goal-update';
+}
+
+/** Narrows a notification to the `connected` variant. */
+export function isConnectedNotification(
+  n: IncomingNotification
+): n is ConnectedNotification {
+  return n.type === 'connected';
+}


### PR DESCRIPTION
- Add src/types/websocket.ts with:
  - AgentMessagePayload, GoalUpdatePayload (incoming payload interfaces)
  - GoalPayload (outgoing goal object for register/update-goal messages)
  - Discriminated union IncomingNotification covering all server message types (connected, agent-message, goal-update, pong, notification)
  - Type guards: isAgentMessageNotification, isGoalUpdateNotification, isConnectedNotification for safe payload narrowing

- Update useNotifications.ts:
  - Remove local IncomingNotification interface; import from types/websocket
  - Re-export IncomingNotification for backward compatibility
  - Type registerGoal and updateGoal args as GoalPayload
  - Fix 'cannot access before declaration' lint: introduce connectRef so ws.onclose calls connectRef.current() instead of closing over connect
  - Fix 'cannot access ref during render' lint: track isConnected in useState updated by onopen/onclose instead of reading wsRef.current

- Update page.tsx:
  - Import and use isConnectedNotification / isAgentMessageNotification guards
  - Replace unsafe payload cast (as any / as { text: string; ... }) with discriminated-union narrowing — full autocomplete on payload properties

Closes #45 