### PR TITLE
feat(frontend): extract GoalTracker into reusable component

### DIFF
--- a/frontend/src/app/components/Button.tsx
+++ b/frontend/src/app/components/Button.tsx
@@ -1,0 +1,49 @@
+import type { ButtonHTMLAttributes, JSX } from "react";
+
+export type ButtonVariant = "primary" | "secondary";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  isLoading?: boolean;
+  loadingLabel?: string;
+}
+
+export function Button({
+  variant = "primary",
+  isLoading = false,
+  disabled,
+  className,
+  children,
+  loadingLabel = "Loading",
+  ...rest
+}: ButtonProps): JSX.Element {
+  const classes = ["btn", `btn-${variant}`, className].filter(Boolean).join(" ");
+
+  return (
+    <button
+      className={classes}
+      disabled={disabled || isLoading}
+      aria-busy={isLoading || undefined}
+      aria-label={isLoading ? loadingLabel : rest["aria-label"]}
+      {...rest}
+    >
+      <span className={`btn-content ${isLoading ? "is-hidden" : ""}`}>{children}</span>
+      {isLoading ? (
+        <span className="btn-loader-wrap" aria-hidden="true">
+          <svg className="btn-loader" viewBox="0 0 24 24" fill="none" focusable="false">
+            <circle
+              cx="12"
+              cy="12"
+              r="9"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray="56.5"
+              strokeDashoffset="18"
+            />
+          </svg>
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/frontend/src/app/components/ChatInterface.tsx
+++ b/frontend/src/app/components/ChatInterface.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { AlertCircle, Bot, CheckCircle2, Send } from "lucide-react";
+
+export interface ChatMessage {
+  id: number;
+  sender: "agent" | "user";
+  text: string;
+  proactive?: boolean;
+  timestamp?: string;
+}
+
+export interface ChatInterfaceProps {
+  messages: ChatMessage[];
+  isTyping: boolean;
+  onSendMessage: (message: string) => void;
+  placeholder?: string;
+}
+
+export function ChatInterface({
+  messages,
+  isTyping,
+  onSendMessage,
+  placeholder = "Ask Smasage to adjust goals...",
+}: ChatInterfaceProps) {
+  const [inputValue, setInputValue] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isTyping]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+
+    onSendMessage(trimmed);
+    setInputValue("");
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-header">
+        <div className="agent-avatar" aria-hidden="true">
+          <Bot size={28} />
+        </div>
+        <div>
+          <h2 style={{ margin: 0, fontSize: "1.25rem" }}>OpenClaw Agent</h2>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              fontSize: "0.85rem",
+              color: "var(--success)",
+            }}
+          >
+            <CheckCircle2
+              size={12}
+              fill="var(--success)"
+              color="var(--bg-card)"
+              aria-hidden="true"
+            />{" "}
+            Online
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="chat-messages"
+        role="log"
+        aria-label="Chat messages"
+        aria-live="polite"
+        aria-relevant="additions"
+      >
+        {messages.map((msg) => (
+          <div key={msg.id} className={`message ${msg.sender}`}>
+            {msg.proactive && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  fontSize: "0.75rem",
+                  color: "var(--accent-primary)",
+                  marginBottom: "4px",
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                }}
+              >
+                <AlertCircle size={12} aria-hidden="true" /> Proactive Nudge
+              </div>
+            )}
+            <div className="message-bubble">{msg.text}</div>
+          </div>
+        ))}
+
+        {isTyping && (
+          <div className="message agent" role="status">
+            <span className="sr-only">Agent is typing...</span>
+            <div className="typing-indicator" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      <form onSubmit={handleSubmit} className="chat-input-container">
+        <input
+          id="chat-input"
+          type="text"
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          aria-label="Message input"
+        />
+        <button type="submit" className="send-button" aria-label="Send message">
+          <Send size={18} aria-hidden="true" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/components/ConnectWalletButton.tsx
+++ b/frontend/src/app/components/ConnectWalletButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loader2 } from 'lucide-react';
+import { Button } from './Button';
 
 export interface ConnectWalletButtonProps {
   onClick: () => void;
@@ -12,10 +12,10 @@ function truncatePublicKey(key: string) {
   return key.slice(0, 4) + '...' + key.slice(-4);
 }
 
-export const ConnectWalletButton: React.FC<ConnectWalletButtonProps> = ({ 
-  onClick, 
-  publicKey, 
-  isConnecting = false 
+export const ConnectWalletButton: React.FC<ConnectWalletButtonProps> = ({
+  onClick,
+  publicKey,
+  isConnecting = false
 }) => {
   const ariaLabel = isConnecting
     ? 'Connecting wallet, please wait'
@@ -24,22 +24,16 @@ export const ConnectWalletButton: React.FC<ConnectWalletButtonProps> = ({
     : 'Connect Stellar wallet';
 
   return (
-    <button 
-      onClick={onClick} 
-      className={`connect-wallet-btn ${isConnecting ? 'connecting' : ''}`}
-      disabled={isConnecting}
+    <Button
+      onClick={onClick}
+      className="connect-wallet-btn"
+      variant="primary"
+      isLoading={isConnecting}
       aria-label={ariaLabel}
-      aria-busy={isConnecting}
+      loadingLabel="Connecting wallet"
     >
-      {isConnecting ? (
-        <>
-          <Loader2 className="spinner" size={16} aria-hidden="true" />
-          <span>Connecting...</span>
-        </>
-      ) : (
-        publicKey ? truncatePublicKey(publicKey) : 'Connect Wallet'
-      )}
-    </button>
+      {publicKey ? truncatePublicKey(publicKey) : 'Connect Wallet'}
+    </Button>
   );
 };
 

--- a/frontend/src/app/components/GoalTracker.tsx
+++ b/frontend/src/app/components/GoalTracker.tsx
@@ -1,0 +1,98 @@
+import { Target } from "lucide-react";
+import { getStatusColor, type ProjectionResult } from "../../utils/goalProjection";
+
+export interface GoalTrackerProps {
+  goalName: string;
+  targetAmount: number;
+  targetDate: string;
+  status: ProjectionResult["status"];
+  progressPercentage: number;
+  remainingAmount: number;
+}
+
+function getStatusClass(status: ProjectionResult["status"]): string {
+  switch (status) {
+    case "Ahead":
+      return "ahead";
+    case "On Track":
+      return "on-track";
+    case "Falling Behind":
+      return "falling-behind";
+    default:
+      return "on-track";
+  }
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatTargetDate(targetDate: string): string {
+  const parsed = new Date(targetDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return targetDate;
+  }
+
+  return parsed.toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function GoalTracker({
+  goalName,
+  targetAmount,
+  targetDate,
+  status,
+  progressPercentage,
+  remainingAmount,
+}: GoalTrackerProps) {
+  const statusColor = getStatusColor(status);
+  const clampedProgress = Math.max(0, Math.min(100, progressPercentage));
+
+  return (
+    <div className="goal-section skeleton-fade-in">
+      <div className="goal-header">
+        <div>
+          <h3 style={{ fontSize: "1.25rem", marginBottom: "4px" }}>{goalName}</h3>
+          <p className="text-muted" style={{ fontSize: "0.9rem" }}>
+            Target: {formatCurrency(targetAmount)} by {formatTargetDate(targetDate)}
+          </p>
+          <div className={`status-indicator ${getStatusClass(status)}`}>
+            Status: {status}
+          </div>
+        </div>
+        <Target size={32} color={statusColor} opacity={0.8} />
+      </div>
+
+      <div className="progress-bar-container">
+        <div
+          className="progress-bar-fill"
+          style={{ width: `${clampedProgress}%` }}
+          role="progressbar"
+          aria-valuenow={Math.round(clampedProgress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="Savings goal progress"
+        ></div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: "0.85rem",
+          color: "var(--text-muted)",
+          fontWeight: 500,
+        }}
+      >
+        <span>{Math.round(clampedProgress)}% Completed</span>
+        <span>{formatCurrency(remainingAmount)} Remaining</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/WalletModal.tsx
+++ b/frontend/src/app/components/WalletModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
+import { Button } from './Button';
 
 interface WalletModalProps {
   isOpen: boolean;
@@ -114,12 +115,13 @@ export const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => 
             Install Freighter
           </a>
 
-          <button
+          <Button
             onClick={onClose}
             className="close-modal"
+            variant="secondary"
           >
             Close
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -48,6 +48,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 }
 
 /* Dashboard Header */
@@ -236,6 +237,129 @@ body {
   .app-container {
     grid-template-columns: 1fr;
     height: auto;
+    max-width: 100%;
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+
+  .glass-panel {
+    width: 100%;
+    min-width: 0;
+    padding: 1.5rem;
+  }
+
+  .stats-grid {
+    gap: 1rem;
+  }
+
+  .goal-section {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-content {
+    padding: 0.85rem 1rem;
+    gap: 0.75rem;
+  }
+
+  .brand {
+    gap: 0.65rem;
+  }
+
+  .brand-name {
+    font-size: 1.25rem;
+  }
+
+  .status-pill {
+    padding: 0.35rem 0.6rem;
+  }
+
+  .app-container {
+    padding: 1rem;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .glass-panel {
+    padding: 1rem;
+    border-radius: 18px;
+  }
+
+  h1 {
+    font-size: 1.85rem;
+  }
+
+  h2 {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .stat-card,
+  .goal-section {
+    padding: 1rem;
+  }
+
+  .stat-value {
+    font-size: 1.7rem;
+  }
+
+  .chat-header {
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .chat-messages {
+    gap: 1rem;
+    padding-right: 0.2rem;
+  }
+
+  .message {
+    max-width: 92%;
+  }
+
+  .message-bubble {
+    padding: 0.85rem 1rem;
+    font-size: 0.9rem;
+    line-height: 1.45;
+  }
+
+  .chat-input-container {
+    margin-top: 1rem;
+  }
+
+  .chat-input-container input {
+    font-size: 0.95rem;
+    padding: 0.9rem 3.5rem 0.9rem 1rem;
+  }
+
+  .btn,
+  .send-button,
+  .modal-close-icon,
+  .install-link,
+  .error-retry-btn {
+    min-height: 44px;
+  }
+
+  .btn {
+    padding: 0.78rem 1.05rem;
+  }
+
+  .connect-wallet-btn {
+    min-width: 132px;
+  }
+
+  .modal-content {
+    min-width: 0;
+    width: min(92vw, 420px);
+    padding: 2.25rem 1.25rem;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -472,7 +472,9 @@ h2 {
 
 .agent .message-bubble {
   background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   border-bottom-left-radius: 4px;
   color: var(--text-main);
 }
@@ -501,7 +503,7 @@ h2 {
   border-radius: 12px;
   border-bottom-left-radius: 4px;
   width: fit-content;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .typing-indicator span {
@@ -621,7 +623,7 @@ h2 {
   outline: none; /* replaced by explicit ring below */
   border-color: var(--accent-primary);
   background: rgba(0, 0, 0, 0.45);
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15), inset 0 0 8px rgba(139, 92, 246, 0.1);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15);
 }
 
 .chat-input-container input:focus-visible {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -133,52 +133,91 @@ body {
   animation: ws-blink 1.2s step-start infinite;
 }
 
-/* Connect Wallet Button */
-.connect-wallet-btn {
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  color: white;
-  border: none;
-  padding: 0.6rem 1.25rem;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+/* Button System */
+.btn {
   position: relative;
-  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 0.72rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-main);
+  cursor: pointer;
+  user-select: none;
+  transition: transform 0.18s ease, box-shadow 0.25s ease, background 0.25s ease, border-color 0.25s ease, filter 0.2s ease;
 }
 
-.connect-wallet-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-  filter: brightness(1.1);
-  box-shadow: 0 6px 16px rgba(139, 92, 246, 0.4);
+.btn:active:not(:disabled) {
+  transform: scale(0.95);
 }
 
-.connect-wallet-btn:active:not(:disabled) {
-  transform: translateY(0) scale(0.98);
-}
-
-.connect-wallet-btn:disabled {
+.btn:disabled {
   cursor: not-allowed;
   opacity: 0.8;
 }
 
-.connect-wallet-btn.connecting {
-  background: linear-gradient(135deg, #4c1d95, #164e63); /* Darker/dimmed version */
-  pointer-events: none;
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
 }
 
-.connect-wallet-btn .spinner {
-  animation: rotate 2s linear infinite;
+.btn-primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #9f75ff, #22d3ee);
+  box-shadow: 0 0 20px rgba(139, 92, 246, 0.4);
+  filter: saturate(1.1);
 }
 
-@keyframes rotate {
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.btn-content {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.18s ease;
+}
+
+.btn-content.is-hidden {
+  opacity: 0;
+}
+
+.btn-loader-wrap {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-loader {
+  width: 1rem;
+  height: 1rem;
+  animation: btn-spin 0.85s linear infinite;
+}
+
+@keyframes btn-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
+}
+
+.connect-wallet-btn {
+  min-width: 140px;
 }
 
 /* Base Layout Container */
@@ -989,29 +1028,8 @@ h2 {
 }
 
 .close-modal {
-  display: block;
   width: 100%;
-  background: transparent;
-  color: var(--text-muted);
-  border: 1px solid var(--border);
-  padding: 0.75rem 1.5rem;
-  border-radius: 12px;
-  cursor: pointer;
   margin-top: 1rem;
-  font-weight: 500;
-  transition: all 0.2s ease;
-}
-
-.close-modal:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: #fff;
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.close-modal:focus-visible {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 3px;
-  background: rgba(255, 255, 255, 0.05);
 }
 
 /* ── WS status indicator animations (Issue #48) ─────────────── */

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,13 +1,6 @@
 "use client";
-import React, { useState, useEffect, useRef, useMemo } from "react";
-import {
-  Bot,
-  Send,
-  Target,
-  Activity,
-  CheckCircle2,
-  AlertCircle,
-} from "lucide-react";
+import React, { useState, useEffect, useMemo } from "react";
+import { Target, Activity } from "lucide-react";
 import { PortfolioStats } from "./components/PortfolioStats";
 import {
   evaluateGoalStatus,
@@ -35,14 +28,7 @@ import {
   PortfolioChartSkeleton,
 } from "./components/SkeletonLoader";
 import { WalletModal } from "./components/WalletModal";
-
-interface Message {
-  id: number;
-  sender: "agent" | "user";
-  text: string;
-  proactive?: boolean;
-  timestamp?: string;
-}
+import { ChatInterface, type ChatMessage } from "./components/ChatInterface";
 
 export default function Home() {
   const { 
@@ -53,14 +39,13 @@ export default function Home() {
     isConnecting 
   } = useFreighter();
 
-  const [messages, setMessages] = useState<Message[]>([
+  const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: 1,
       sender: "agent",
       text: "Welcome to Smasage! 👋 I'm OpenClaw, your personal AI savings assistant natively built on Stellar. What financial goal can we crush today?",
     },
   ]);
-  const [inputState, setInputState] = useState("");
   const [isTyping, setIsTyping] = useState(false);
 
   const [allocations, setAllocations] = useState<AssetAllocation[]>(
@@ -69,7 +54,6 @@ export default function Home() {
 
   const [wsConnected, setWsConnected] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Goal data (Memoized to avoid unnecessary effect triggers)
   const goalData = useMemo<GoalData>(() => ({
@@ -100,14 +84,14 @@ export default function Home() {
       } else if (isAgentMessageNotification(notification)) {
         // payload is fully typed as AgentMessagePayload — no cast needed
         const { text, proactive, timestamp } = notification.payload;
-        const agentMsg: Message = {
+        const agentMsg: ChatMessage = {
           id: Date.now(),
           sender: "agent",
           text,
           proactive,
           timestamp,
         };
-        setMessages((prev) => [...prev, agentMsg]);
+        setMessages((prev: ChatMessage[]) => [...prev, agentMsg]);
 
         // Parse allocations if present
         const parsedAllocations = parseAllocationsFromMessage(text);
@@ -128,11 +112,6 @@ export default function Home() {
     return () => clearTimeout(t);
   }, []);
 
-  // Auto scroll
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, isTyping]);
-
   // Register goal with notification server on mount
   useEffect(() => {
     if (wsConnected) {
@@ -146,28 +125,27 @@ export default function Home() {
     }
   }, [wsConnected, registerGoal, goalData]);
 
-  const handleSendMessage = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!inputState.trim()) return;
+  const handleSendMessage = (message: string) => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
 
-    const userMsg: Message = {
+    const userMsg: ChatMessage = {
       id: Date.now(),
       sender: "user",
-      text: inputState,
+      text: trimmed,
     };
-    setMessages((prev) => [...prev, userMsg]);
-    setInputState("");
+    setMessages((prev: ChatMessage[]) => [...prev, userMsg]);
     setIsTyping(true);
 
     // Mock agent response delay
     setTimeout(() => {
       setIsTyping(false);
-      const agentMsg: Message = {
+      const agentMsg: ChatMessage = {
         id: Date.now() + 1,
         sender: "agent",
         text: "That's a great goal. I'll allocate 60% to Stellar Blend for safe yield, and the rest to Soroswap XLM/USDC LP to accelerate returns. Does that sound good?",
       };
-      setMessages((prev) => [...prev, agentMsg]);
+      setMessages((prev: ChatMessage[]) => [...prev, agentMsg]);
 
       // Parse allocations from agent message
       const parsedAllocations = parseAllocationsFromMessage(agentMsg.text);
@@ -299,97 +277,11 @@ export default function Home() {
 
           {/* Right Panel - Chat Agent */}
           <div className="glass-panel">
-            <div className="chat-container">
-              <div className="chat-header">
-                <div className="agent-avatar" aria-hidden="true">
-                  <Bot size={28} />
-                </div>
-                <div>
-                  <h2 style={{ margin: 0, fontSize: "1.25rem" }}>
-                    OpenClaw Agent
-                  </h2>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "6px",
-                      fontSize: "0.85rem",
-                      color: "var(--success)",
-                    }}
-                  >
-                    <CheckCircle2
-                      size={12}
-                      fill="var(--success)"
-                      color="var(--bg-card)"
-                      aria-hidden="true"
-                    />{" "}
-                    Online
-                  </div>
-                </div>
-              </div>
-
-              <div
-                className="chat-messages"
-                role="log"
-                aria-label="Chat messages"
-                aria-live="polite"
-                aria-relevant="additions"
-              >
-                {messages.map((msg) => (
-                  <div key={msg.id} className={`message ${msg.sender}`}>
-                    {msg.proactive && (
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "6px",
-                          fontSize: "0.75rem",
-                          color: "var(--accent-primary)",
-                          marginBottom: "4px",
-                          fontWeight: 600,
-                          textTransform: "uppercase",
-                        }}
-                      >
-                        <AlertCircle size={12} aria-hidden="true" /> Proactive Nudge
-                      </div>
-                    )}
-                    <div className="message-bubble">{msg.text}</div>
-                  </div>
-                ))}
-                {isTyping && (
-                  <div className="message agent" role="status">
-                    <span className="sr-only">Agent is typing…</span>
-                    <div className="typing-indicator" aria-hidden="true">
-                      <span></span>
-                      <span></span>
-                      <span></span>
-                    </div>
-                  </div>
-                )}
-                <div ref={messagesEndRef} />
-              </div>
-
-              <form
-                onSubmit={handleSendMessage}
-                className="chat-input-container"
-              >
-                <input
-                  id="chat-input"
-                  type="text"
-                  placeholder="Ask Smasage to adjust goals..."
-                  value={inputState}
-                  onChange={(e) => setInputState(e.target.value)}
-                  aria-label="Message input"
-                />
-                <button
-                  type="submit"
-                  className="send-button"
-                  aria-label="Send message"
-                >
-                  <Send size={18} aria-hidden="true" />
-                </button>
-              </form>
-            </div>
+            <ChatInterface
+              messages={messages}
+              isTyping={isTyping}
+              onSendMessage={handleSendMessage}
+            />
           </div>
         </main>
       </>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -31,12 +31,12 @@ import { WalletModal } from "./components/WalletModal";
 import { ChatInterface, type ChatMessage } from "./components/ChatInterface";
 
 export default function Home() {
-  const { 
-    publicKey, 
-    connect, 
-    showInstallModal, 
+  const {
+    publicKey,
+    connect,
+    showInstallModal,
     setShowInstallModal,
-    isConnecting 
+    isConnecting
   } = useFreighter();
 
   const [messages, setMessages] = useState<ChatMessage[]>([

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 import React, { useState, useEffect, useMemo } from "react";
-import { Target, Activity } from "lucide-react";
+import { Activity } from "lucide-react";
 import { PortfolioStats } from "./components/PortfolioStats";
 import {
   evaluateGoalStatus,
-  getStatusColor,
   type GoalData,
 } from "../utils/goalProjection";
 import PortfolioChart from "./PortfolioChart";
@@ -29,6 +28,7 @@ import {
 } from "./components/SkeletonLoader";
 import { WalletModal } from "./components/WalletModal";
 import { ChatInterface, type ChatMessage } from "./components/ChatInterface";
+import { GoalTracker } from "./components/GoalTracker";
 
 export default function Home() {
   const {
@@ -193,56 +193,14 @@ export default function Home() {
             {isLoading ? (
               <GoalTrackerSkeleton />
             ) : (
-              <div className="goal-section skeleton-fade-in">
-                <div className="goal-header">
-                  <div>
-                    <h3 style={{ fontSize: "1.25rem", marginBottom: "4px" }}>
-                      European Vacation
-                    </h3>
-                    <p className="text-muted" style={{ fontSize: "0.9rem" }}>
-                      Target: $18,000 by Aug 2026
-                    </p>
-                    <p
-                      style={{
-                        fontSize: "0.85rem",
-                        color: getStatusColor(goalStatus),
-                        fontWeight: 600,
-                        marginTop: "4px",
-                      }}
-                    >
-                      Status: {goalStatus}
-                    </p>
-                  </div>
-                  <Target
-                    size={32}
-                    color={getStatusColor(goalStatus)}
-                    opacity={0.8}
-                  />
-                </div>
-                <div className="progress-bar-container">
-                  <div
-                    className="progress-bar-fill"
-                    style={{ width: `${progress}%` }}
-                    role="progressbar"
-                    aria-valuenow={Math.round(progress)}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-label="Savings goal progress"
-                  ></div>
-                </div>
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    fontSize: "0.85rem",
-                    color: "var(--text-muted)",
-                    fontWeight: 500,
-                  }}
-                >
-                  <span>68% Completed</span>
-                  <span>$5,550 Remaining</span>
-                </div>
-              </div>
+              <GoalTracker
+                goalName="European Vacation"
+                targetAmount={goalData.targetAmount}
+                targetDate={goalData.targetDate}
+                status={goalStatus}
+                progressPercentage={progress}
+                remainingAmount={goalData.targetAmount - goalData.currentBalance}
+              />
             )}
 
             <div className="allocation-list">


### PR DESCRIPTION


create typed GoalTracker component for goal title, target, status, progress, and remaining amount
move inline goal-section JSX out of page layout into the new component
encapsulate status display handling while preserving semantic status visuals
keep animated gradient progress bar and shimmer behavior unchanged
Closes #29