### PR TITLE
feat(ui): add reusable GlassPanel component

### DIFF
--- a/frontend/src/app/components/GlassPanel.tsx
+++ b/frontend/src/app/components/GlassPanel.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface GlassPanelProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function GlassPanel({ children, className }: GlassPanelProps) {
+  return (
+    <div className={`glass-panel${className ? ` ${className}` : ""}`}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -29,6 +29,7 @@ import {
 import { WalletModal } from "./components/WalletModal";
 import { ChatInterface, type ChatMessage } from "./components/ChatInterface";
 import { GoalTracker } from "./components/GoalTracker";
+import { GlassPanel } from "./components/GlassPanel";
 
 export default function Home() {
   const {
@@ -172,7 +173,7 @@ export default function Home() {
         />
         <main className="app-container" aria-label="Portfolio dashboard">
           {/* Left Panel - Dashboard */}
-          <div className="glass-panel">
+          <GlassPanel>
             <h1>Smasage Portfolio</h1>
             <p className="text-muted" style={{ marginBottom: "2.5rem" }}>
               Real-time on-chain tracking • Stellar Mainnet 🚀
@@ -231,16 +232,16 @@ export default function Home() {
                 </div>
               )}
             </div>
-          </div>
+          </GlassPanel>
 
           {/* Right Panel - Chat Agent */}
-          <div className="glass-panel">
+          <GlassPanel>
             <ChatInterface
               messages={messages}
               isTyping={isTyping}
               onSendMessage={handleSendMessage}
             />
-          </div>
+          </GlassPanel>
         </main>
       </>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary

Implements the reusable `GlassPanel` wrapper component requested in #32.

### New file: `frontend/src/app/components/GlassPanel.tsx`

```tsx
interface GlassPanelProps {
  children: React.ReactNode;
  className?: string;
}

export function GlassPanel({ children, className }: GlassPanelProps) {
  return (
    <div className={`glass-panel${className ? ` ${className}` : ""}`}>
      {children}
    </div>
  );
}
```

- Accepts `children` and an optional `className` prop (merged after `glass-panel`)
- Applies `.glass-panel` internally — the class in `globals.css` already enforces:
  - `backdrop-filter: blur(16px)` / `-webkit-backdrop-filter: blur(16px)`
  - `background: rgba(24, 24, 27, 0.7)` via `--glass-bg`
  - `border: 1px solid rgba(255, 255, 255, 0.08)` via `--glass-border`
  - hover: `transform: translateY(-2px)` + deepened `box-shadow`

### Updated: `frontend/src/app/page.tsx`

Both raw `<div className="glass-panel">` elements replaced with `<GlassPanel>`.

## Acceptance Criteria

- [x] `GlassPanel` correctly renders its children
- [x] `page.tsx` uses `GlassPanel` instead of raw `div` tags with `className="glass-panel"`

Closes #32