### PR TITLE
feat: root npm test in CI, agent audit gate, dependency policy, deposit balance assertions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/agent"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches: ["main", "master"]
 
 jobs:
+  # #173 — run root-level jest suite
+  test-root:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "./package-lock.json"
+      - run: npm ci
+      - run: npm test
+
   test-and-build-frontend:
     runs-on: ubuntu-latest
     defaults:
@@ -35,6 +49,9 @@ jobs:
         with:
           node-version: 20
       - run: npm install
+      # #176 — gate on high-severity vulnerabilities in agent dependencies
+      - name: Audit agent dependencies (high gate)
+        run: npm audit --audit-level=high
       - run: npm test --ignore-scripts || echo "Agent tests completed"
 
   build-contracts:

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -360,6 +360,13 @@ impl SmasageYieldRouter {
         let usdc_token =
             Self::get_usdc_token(env.clone()).ok_or(ContractError::UsdcTokenNotInitialized)?;
         let token_client = TokenClient::new(env, &usdc_token);
+
+        // Issue #165: Assert sender has sufficient balance before initiating transfer
+        let sender_balance = token_client.balance(from);
+        if sender_balance < amount {
+            return Err(ContractError::InsufficientBalance);
+        }
+
         token_client.transfer(from, &env.current_contract_address(), &amount);
         Ok(())
     }
@@ -590,6 +597,13 @@ impl SmasageYieldRouter {
             .get(&DataKey::UsdcToken)
             .ok_or(ContractError::UsdcTokenNotInitialized)?;
         let usdc = TokenClient::new(&env, &usdc_addr);
+
+        // Issue #165: Assert sender has sufficient token balance before deposit transfer
+        let user_balance = usdc.balance(&from);
+        if user_balance < amount {
+            return Err(ContractError::InsufficientBalance);
+        }
+
         usdc.transfer(&from, &env.current_contract_address(), &amount);
 
         let mut balance: i128 = env
@@ -1045,12 +1059,16 @@ mod test {
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
 
-        // Register mocks
+        // Use StatefulMockToken for USDC so balance assertions in deposit pass
         let router_id = env.register(MockRouter, ());
-        let usdc_id = env.register(MockToken, ());
+        let usdc_id = env.register(StatefulMockToken, ());
         let xlm_id = env.register(MockToken, ());
 
         env.mock_all_auths();
+
+        // Mint enough USDC for two 1000-unit deposits
+        StatefulMockTokenClient::new(&env, &usdc_id).initialize(&user);
+        StatefulMockTokenClient::new(&env, &usdc_id).mint(&user, &2000);
 
         client.initialize(&admin);
         client.initialize_soroswap(&admin, &router_id, &usdc_id, &xlm_id);
@@ -1075,9 +1093,13 @@ mod test {
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
         let router = env.register(MockRouter, ());
-        let usdc = env.register(MockToken, ());
+        let usdc = env.register(StatefulMockToken, ());
         let xlm = env.register(MockToken, ());
         env.mock_all_auths();
+
+        // Mint enough USDC for the single 1000-unit deposit
+        StatefulMockTokenClient::new(&env, &usdc).initialize(&user);
+        StatefulMockTokenClient::new(&env, &usdc).mint(&user, &1000);
 
         client.initialize(&admin);
         client.initialize_soroswap(&admin, &router, &usdc, &xlm);
@@ -1107,9 +1129,13 @@ mod test {
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
         let router = env.register(MockRouter, ());
-        let usdc = env.register(MockToken, ());
+        let usdc = env.register(StatefulMockToken, ());
         let xlm = env.register(MockToken, ());
         env.mock_all_auths();
+
+        // Mint enough USDC for the 2000-unit deposit
+        StatefulMockTokenClient::new(&env, &usdc).initialize(&user);
+        StatefulMockTokenClient::new(&env, &usdc).mint(&user, &2000);
 
         client.initialize(&admin);
         client.initialize_soroswap(&admin, &router, &usdc, &xlm);
@@ -1189,6 +1215,16 @@ mod test {
                     .persistent()
                     .get(&TokenDataKey::Balance(id))
                     .unwrap_or(0)
+            }
+
+            // no-op approve required when this token is used in LP-flow tests
+            pub fn approve(
+                _env: Env,
+                _from: Address,
+                _spender: Address,
+                _amount: i128,
+                _expiration_ledger: u32,
+            ) {
             }
         }
     }
@@ -1954,5 +1990,61 @@ mod test {
 
         let result = client.try_initialize_soroswap(&admin, &router, &usdc, &xlm);
         assert_eq!(result, Ok(()));
+    }
+
+    // ============================================
+    // Issue #165 — Token balance assertions
+    // ============================================
+
+    #[test]
+    fn test_deposit_rejects_insufficient_balance() {
+        let env = Env::default();
+        let contract_id = env.register(SmasageYieldRouter, ());
+        let client = SmasageYieldRouterClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let router = env.register(MockRouter, ());
+        let usdc = env.register(StatefulMockToken, ());
+        let xlm = env.register(MockToken, ());
+
+        env.mock_all_auths();
+
+        // Mint only 100 USDC — less than the 1000 deposit attempt
+        StatefulMockTokenClient::new(&env, &usdc).initialize(&user);
+        StatefulMockTokenClient::new(&env, &usdc).mint(&user, &100);
+
+        client.initialize(&admin);
+        client.initialize_soroswap(&admin, &router, &usdc, &xlm);
+
+        let result = client.try_deposit(&user, &1000, &0, &0, &0);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientBalance)));
+    }
+
+    #[test]
+    fn test_supply_to_blend_rejects_insufficient_balance() {
+        let env = Env::default();
+        let contract_id = env.register(SmasageYieldRouter, ());
+        let client = SmasageYieldRouterClient::new(&env, &contract_id);
+
+        let blend_pool_id = env.register(MockBlendPool, ());
+        let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
+
+        let token_id = env.register(StatefulMockToken, ());
+        let token_client = StatefulMockTokenClient::new(&env, &token_id);
+
+        let user = Address::generate(&env);
+
+        env.mock_all_auths();
+
+        // Mint only 100 USDC — less than the 1000 supply attempt
+        token_client.initialize(&user);
+        token_client.mint(&user, &100);
+
+        blend_pool_client.initialize(&INDEX_RATE_PRECISION);
+        client.initialize_blend(&blend_pool_id, &token_id);
+
+        let result = client.try_supply_to_blend(&user, &1000);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientBalance)));
     }
 }

--- a/docs/dependency-update-policy.md
+++ b/docs/dependency-update-policy.md
@@ -1,0 +1,33 @@
+# Dependency Update Policy
+
+## Scope
+
+This policy applies to all package managers used in this repository:
+- **npm** — root workspace, `agent/`, `frontend/`
+- **Cargo** — `contracts/`
+
+## Update cadence
+
+| Severity | Action | Timeline |
+|----------|--------|----------|
+| Critical / High CVE | Patch immediately | Within 2 business days of disclosure |
+| Moderate CVE | Schedule patch | Within the next sprint (≤ 2 weeks) |
+| Low CVE | Batch with routine updates | Monthly |
+| No CVE (minor/patch) | Routine upgrade | Monthly |
+| Major version bump | Planned upgrade with testing | Quarterly or as needed |
+
+## Process
+
+1. **Detection** — The `npm audit --audit-level=high` gate in CI blocks merges when any high or critical vulnerability is present in `agent/` dependencies. Developers should also run `npm audit` locally before raising a PR.
+2. **Assessment** — Confirm whether the vulnerable code path is reachable in this project. Document findings in the PR description if the upgrade is non-trivial.
+3. **Upgrade** — Prefer the minimum version that resolves the issue. Update the lock file (`package-lock.json` / `Cargo.lock`) and run the full test suite locally before opening a PR.
+4. **Review** — All dependency upgrades require at least one reviewer approval before merging to `main`.
+5. **Lock-file commits** — Always commit updated lock files together with `package.json` / `Cargo.toml` changes so CI operates on a reproducible dependency tree.
+
+## Automation
+
+Dependabot is configured (see `.github/dependabot.yml`) to open weekly PRs for outdated dependencies across npm and Cargo workspaces. Maintainers should review and merge these promptly to keep the audit baseline clean.
+
+## Overrides and exceptions
+
+If a vulnerability cannot be patched immediately (e.g., no fix released yet, or the upgrade is a major breaking change), open a tracking issue labelled `security` and document the accepted risk, the mitigating controls in place, and the expected resolution date.


### PR DESCRIPTION
## Summary

- **#173** — Adds a `test-root` CI job that runs `npm ci` + `npm test` at the repository root so the root-level Jest suite is gated on every push and PR (previously CI only tested `frontend/` and `agent/`).
- **#176** — Adds `npm audit --audit-level=high` as a mandatory step in the `test-agent` CI job. The job fails if any high or critical vulnerability is present in the agent's dependency tree, blocking merges until the issue is resolved.
- **#182** — Adds `docs/dependency-update-policy.md` documenting update cadence (critical/high within 2 business days, moderate within a sprint, routine monthly), the review and lock-file process, and exception handling. Adds `.github/dependabot.yml` for automated weekly dependency PRs across all four package ecosystems (root npm, agent npm, frontend npm, contracts Cargo).
- **#165** — Adds explicit `InsufficientBalance` pre-transfer assertions in both `deposit()` and `transfer_usdc_from_user()` so callers receive a typed contract error instead of relying on the token contract to panic. Updates `test_soroswap_integration`, `test_withdraw_unwinds_blend_and_lp`, and `test_gold_allocation_tracking` to use `StatefulMockToken` with proper balance minting so `cargo test` continues to pass. Adds a no-op `approve()` to `StatefulMockToken` to support LP-flow tests. Adds two new tests: `test_deposit_rejects_insufficient_balance` and `test_supply_to_blend_rejects_insufficient_balance`.

## Test plan

- [ ] `cargo check` passes in `contracts/` (verified locally)
- [ ] `cargo test` passes in `contracts/` — all existing tests still pass plus 2 new assertion tests
- [ ] `cargo fmt --all -- --check` passes
- [ ] CI `test-root` job runs and `npm test` passes at repo root
- [ ] CI `test-agent` audit step runs; merge is blocked if high CVEs are found in agent deps
- [ ] `docs/dependency-update-policy.md` and `.github/dependabot.yml` are present and accurate

Closes #165
Closes #173
Closes #176
Closes #182