### PR TITLE
feat: agent env validation, structured logging, graceful shutdown + frontend npm audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: "./frontend/package-lock.json"
       - run: npm ci || npm install
+      # #175 — gate on high-severity vulnerabilities in frontend dependencies
+      - name: Audit frontend dependencies (high gate)
+        run: npm audit --audit-level=high
       - run: npm run build
 
   test-agent:

--- a/agent/env.test.ts
+++ b/agent/env.test.ts
@@ -1,0 +1,65 @@
+import { validateEnv, loadAgentEnv } from './env';
+
+describe('validateEnv', () => {
+  it('accepts the minimal required env and applies defaults', () => {
+    expect(validateEnv({ GEMINI_API_KEY: 'secret' })).toEqual({
+      ok: true,
+      env: { GEMINI_API_KEY: 'secret', NOTIFICATION_PORT: 3001 },
+    });
+  });
+
+  it('uses the provided NOTIFICATION_PORT when valid', () => {
+    expect(validateEnv({ GEMINI_API_KEY: 'secret', NOTIFICATION_PORT: '4500' })).toEqual({
+      ok: true,
+      env: { GEMINI_API_KEY: 'secret', NOTIFICATION_PORT: 4500 },
+    });
+  });
+
+  it('reports a missing required key', () => {
+    expect(validateEnv({})).toEqual({
+      ok: false,
+      errors: ['GEMINI_API_KEY is required'],
+    });
+  });
+
+  it('treats an empty / whitespace-only required key as missing', () => {
+    expect(validateEnv({ GEMINI_API_KEY: '   ' })).toEqual({
+      ok: false,
+      errors: ['GEMINI_API_KEY is required'],
+    });
+  });
+
+  it('rejects non-integer NOTIFICATION_PORT', () => {
+    expect(validateEnv({ GEMINI_API_KEY: 'k', NOTIFICATION_PORT: 'abc' })).toEqual({
+      ok: false,
+      errors: [expect.stringMatching(/NOTIFICATION_PORT must be an integer/)],
+    });
+  });
+
+  it('rejects an out-of-range NOTIFICATION_PORT', () => {
+    expect(validateEnv({ GEMINI_API_KEY: 'k', NOTIFICATION_PORT: '0' }).ok).toBe(false);
+    expect(validateEnv({ GEMINI_API_KEY: 'k', NOTIFICATION_PORT: '70000' }).ok).toBe(false);
+  });
+
+  it('reports every error at once (one-pass fix)', () => {
+    expect(validateEnv({ NOTIFICATION_PORT: 'oops' })).toEqual({
+      ok: false,
+      errors: expect.arrayContaining([
+        expect.stringMatching(/GEMINI_API_KEY is required/),
+        expect.stringMatching(/NOTIFICATION_PORT must be an integer/),
+      ]),
+    });
+  });
+});
+
+describe('loadAgentEnv', () => {
+  it('returns the typed env on success', () => {
+    const env = loadAgentEnv({ GEMINI_API_KEY: 'k', NOTIFICATION_PORT: '8080' });
+    expect(env).toEqual({ GEMINI_API_KEY: 'k', NOTIFICATION_PORT: 8080 });
+  });
+
+  it('throws a multi-line error listing every problem', () => {
+    expect(() => loadAgentEnv({ NOTIFICATION_PORT: 'oops' })).toThrow(/GEMINI_API_KEY is required/);
+    expect(() => loadAgentEnv({ NOTIFICATION_PORT: 'oops' })).toThrow(/NOTIFICATION_PORT/);
+  });
+});

--- a/agent/env.ts
+++ b/agent/env.ts
@@ -1,0 +1,84 @@
+/**
+ * Agent environment validation — Issue #147.
+ *
+ * Centralises the agent's environment-variable contract so every entry point
+ * fails the same way and with the same messages. `validateEnv` is pure and
+ * unit-tested; `loadAgentEnv` is the thin wrapper that reads `process.env` and
+ * throws on misconfiguration.
+ */
+
+/** The shape of a fully validated agent env. */
+export interface AgentEnv {
+  GEMINI_API_KEY: string;
+  NOTIFICATION_PORT: number;
+}
+
+export interface ValidateEnvSuccess {
+  ok: true;
+  env: AgentEnv;
+}
+
+export interface ValidateEnvFailure {
+  ok: false;
+  errors: string[];
+}
+
+export type ValidateEnvResult = ValidateEnvSuccess | ValidateEnvFailure;
+
+export const DEFAULT_NOTIFICATION_PORT = 3001;
+const MIN_PORT = 1;
+const MAX_PORT = 65535;
+
+/**
+ * Pure validator: takes a raw map of env vars and returns either the typed
+ * `AgentEnv` or a list of human-readable error messages. Does not throw and
+ * does not touch `process.env` itself.
+ */
+export function validateEnv(raw: Record<string, string | undefined>): ValidateEnvResult {
+  const errors: string[] = [];
+
+  // GEMINI_API_KEY — required, non-empty string
+  const apiKeyRaw = raw.GEMINI_API_KEY;
+  let apiKey: string | undefined;
+  if (apiKeyRaw === undefined || apiKeyRaw.trim() === '') {
+    errors.push('GEMINI_API_KEY is required');
+  } else {
+    apiKey = apiKeyRaw;
+  }
+
+  // NOTIFICATION_PORT — optional integer in [1, 65535], defaults to 3001
+  const portRaw = raw.NOTIFICATION_PORT;
+  let port: number = DEFAULT_NOTIFICATION_PORT;
+  if (portRaw !== undefined && portRaw !== '') {
+    const parsed = Number(portRaw);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+      errors.push(`NOTIFICATION_PORT must be an integer (got ${JSON.stringify(portRaw)})`);
+    } else if (parsed < MIN_PORT) {
+      errors.push(`NOTIFICATION_PORT must be >= ${MIN_PORT}`);
+    } else if (parsed > MAX_PORT) {
+      errors.push(`NOTIFICATION_PORT must be <= ${MAX_PORT}`);
+    } else {
+      port = parsed;
+    }
+  }
+
+  if (errors.length > 0 || apiKey === undefined) {
+    return { ok: false, errors };
+  }
+  return { ok: true, env: { GEMINI_API_KEY: apiKey, NOTIFICATION_PORT: port } };
+}
+
+/**
+ * Read & validate `process.env` for the agent. Throws a single error whose
+ * message lists every misconfiguration so the operator can fix them in one
+ * pass.
+ */
+export function loadAgentEnv(source: Record<string, string | undefined> = process.env): AgentEnv {
+  const result = validateEnv(source);
+  if (result.ok === false) {
+    throw new Error(
+      `Agent environment is misconfigured:\n  - ${result.errors.join('\n  - ')}`,
+    );
+  }
+  return result.env;
+}

--- a/agent/graceful-shutdown.test.ts
+++ b/agent/graceful-shutdown.test.ts
@@ -1,0 +1,168 @@
+import {
+  registerGracefulShutdown,
+  type SignalEmitter,
+  type ShutdownHandler,
+} from './graceful-shutdown';
+import type { Logger } from './logger';
+
+function fakeLogger(): Logger & { records: Array<{ level: string; msg: string; meta?: Record<string, unknown> }> } {
+  const records: Array<{ level: string; msg: string; meta?: Record<string, unknown> }> = [];
+  const log = (level: string) => (msg: string, meta?: Record<string, unknown>) => {
+    records.push({ level, msg, meta });
+  };
+  const logger = {
+    debug: log('debug'),
+    info: log('info'),
+    warn: log('warn'),
+    error: log('error'),
+    child: () => logger,
+    records,
+  };
+  return logger as Logger & typeof logger;
+}
+
+interface FakeSignalEmitter extends SignalEmitter {
+  fire(signal: 'SIGTERM' | 'SIGINT'): void;
+}
+
+function fakeSignals(): FakeSignalEmitter {
+  const listeners: Record<'SIGTERM' | 'SIGINT', Array<() => void>> = {
+    SIGTERM: [],
+    SIGINT: [],
+  };
+  return {
+    on(signal, listener) {
+      listeners[signal].push(listener);
+    },
+    fire(signal) {
+      for (const l of listeners[signal]) l();
+    },
+  };
+}
+
+describe('registerGracefulShutdown', () => {
+  it('runs every handler in order on SIGTERM and exits cleanly', async () => {
+    const calls: string[] = [];
+    const handlers: ShutdownHandler[] = [
+      () => {
+        calls.push('a');
+      },
+      async () => {
+        calls.push('b');
+      },
+    ];
+    const signals = fakeSignals();
+    const exit = jest.fn<void, [number]>();
+    const logger = fakeLogger();
+
+    const trigger = registerGracefulShutdown({ logger, handlers, signals, exit });
+    signals.fire('SIGTERM');
+    await trigger(); // ensure pending promise completes
+    // Allow scheduled microtasks to settle.
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(calls).toEqual(['a', 'b']);
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.records.find((r) => r.msg === 'graceful shutdown complete')).toBeTruthy();
+  });
+
+  it('SIGINT triggers the same procedure', async () => {
+    const calls: string[] = [];
+    const signals = fakeSignals();
+    const exit = jest.fn<void, [number]>();
+    registerGracefulShutdown({
+      logger: fakeLogger(),
+      handlers: [
+        () => {
+          calls.push('only');
+        },
+      ],
+      signals,
+      exit,
+    });
+    signals.fire('SIGINT');
+    await new Promise<void>((r) => setImmediate(r));
+    expect(calls).toEqual(['only']);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('ignores a duplicate signal during shutdown (idempotent)', async () => {
+    const calls: number[] = [];
+    let release: () => void = () => {};
+    const signals = fakeSignals();
+    const exit = jest.fn<void, [number]>();
+    const logger = fakeLogger();
+    registerGracefulShutdown({
+      logger,
+      handlers: [
+        () =>
+          new Promise<void>((r) => {
+            calls.push(1);
+            release = r;
+          }),
+      ],
+      signals,
+      exit,
+    });
+
+    signals.fire('SIGTERM');
+    // Second signal while the first is in flight should be a warning, not a re-run.
+    signals.fire('SIGTERM');
+    release();
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(calls).toEqual([1]);
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(
+      logger.records.some(
+        (r) => r.level === 'warn' && r.msg.includes('shutdown already in progress'),
+      ),
+    ).toBe(true);
+  });
+
+  it('continues past a failing handler and logs the error', async () => {
+    const seen: string[] = [];
+    const signals = fakeSignals();
+    const exit = jest.fn<void, [number]>();
+    const logger = fakeLogger();
+    registerGracefulShutdown({
+      logger,
+      handlers: [
+        () => {
+          throw new Error('first failed');
+        },
+        () => {
+          seen.push('second ran');
+        },
+      ],
+      signals,
+      exit,
+    });
+    signals.fire('SIGTERM');
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(seen).toEqual(['second ran']);
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logger.records.find((r) => r.msg === 'shutdown handler failed')).toBeTruthy();
+  });
+
+  it('hard-exits on shutdown timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const signals = fakeSignals();
+      const exit = jest.fn<void, [number]>();
+      registerGracefulShutdown({
+        logger: fakeLogger(),
+        handlers: [() => new Promise<void>(() => {})], // never resolves
+        signals,
+        exit,
+        timeoutMs: 50,
+      });
+      signals.fire('SIGTERM');
+      jest.advanceTimersByTime(50);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/agent/graceful-shutdown.ts
+++ b/agent/graceful-shutdown.ts
@@ -1,0 +1,110 @@
+/**
+ * Graceful shutdown helper — Issue #145.
+ *
+ * Registers SIGTERM/SIGINT handlers that:
+ *   1. Run an ordered list of cleanup handlers (e.g. close WebSocket clients,
+ *      close the HTTP server).
+ *   2. Are idempotent — a second signal during shutdown is logged but does not
+ *      re-trigger the handlers.
+ *   3. Honour a hard timeout so a hanging cleanup cannot wedge a container
+ *      that the orchestrator is trying to recycle.
+ *
+ * The default `signal()` is `process.kill` style (subscribe via
+ * `process.on(signal, fn)`) and the default `exit()` is `process.exit`, both
+ * injectable so the helper can be unit-tested without touching the real
+ * process.
+ */
+
+import type { Logger } from './logger';
+
+export type ShutdownHandler = () => void | Promise<void>;
+
+export interface SignalEmitter {
+  on(signal: 'SIGTERM' | 'SIGINT', listener: () => void): void;
+}
+
+export interface RegisterGracefulShutdownOptions {
+  logger: Logger;
+  handlers: ShutdownHandler[];
+  /** Hard cap on total shutdown time, in ms. Defaults to 10s. */
+  timeoutMs?: number;
+  /** Injectable signal emitter (defaults to `process`). */
+  signals?: SignalEmitter;
+  /** Injectable exit (defaults to `process.exit`). */
+  exit?: (code: number) => void;
+}
+
+interface ShutdownState {
+  inProgress: boolean;
+  completed: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Wire SIGTERM and SIGINT to the same shutdown procedure. Returns a function
+ * that triggers shutdown manually (useful for tests).
+ */
+export function registerGracefulShutdown(
+  options: RegisterGracefulShutdownOptions,
+): () => Promise<void> {
+  const {
+    logger,
+    handlers,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    signals = process,
+    exit = (code: number) => process.exit(code),
+  } = options;
+
+  const state: ShutdownState = { inProgress: false, completed: false };
+
+  async function shutdown(signal: 'SIGTERM' | 'SIGINT' | 'manual'): Promise<void> {
+    if (state.completed) {
+      logger.warn('shutdown already completed; ignoring signal', { signal });
+      return;
+    }
+    if (state.inProgress) {
+      logger.warn('shutdown already in progress; ignoring signal', { signal });
+      return;
+    }
+    state.inProgress = true;
+    logger.info('graceful shutdown started', { signal });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      logger.error('graceful shutdown timed out; forcing exit', { timeoutMs });
+      exit(1);
+    }, timeoutMs);
+    // Don't keep the event loop alive solely for the shutdown timer.
+    if (typeof (timer as { unref?: () => void }).unref === 'function') {
+      (timer as { unref: () => void }).unref();
+    }
+
+    try {
+      for (let i = 0; i < handlers.length; i++) {
+        try {
+          await handlers[i]();
+        } catch (err) {
+          logger.error('shutdown handler failed', { index: i, err });
+        }
+      }
+    } finally {
+      clearTimeout(timer);
+      state.completed = true;
+      if (!timedOut) {
+        logger.info('graceful shutdown complete');
+        exit(0);
+      }
+    }
+  }
+
+  signals.on('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
+  signals.on('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
+
+  return () => shutdown('manual');
+}

--- a/agent/logger.test.ts
+++ b/agent/logger.test.ts
@@ -1,0 +1,98 @@
+import { formatLogLine, createLogger } from './logger';
+
+const FROZEN = new Date('2026-05-29T10:00:00.000Z');
+
+describe('formatLogLine', () => {
+  it('emits a JSON record with the standard fields', () => {
+    const line = formatLogLine({
+      level: 'info',
+      component: 'notification-monitor',
+      msg: 'started',
+      now: FROZEN,
+    });
+    expect(JSON.parse(line)).toEqual({
+      ts: '2026-05-29T10:00:00.000Z',
+      level: 'info',
+      component: 'notification-monitor',
+      msg: 'started',
+    });
+  });
+
+  it('merges arbitrary meta fields onto the record', () => {
+    const line = formatLogLine({
+      level: 'warn',
+      component: 'notification-monitor',
+      msg: 'goal fell behind',
+      meta: { userId: 'u-1', shortfall: 42.5 },
+      now: FROZEN,
+    });
+    expect(JSON.parse(line)).toEqual({
+      ts: '2026-05-29T10:00:00.000Z',
+      level: 'warn',
+      component: 'notification-monitor',
+      msg: 'goal fell behind',
+      userId: 'u-1',
+      shortfall: 42.5,
+    });
+  });
+
+  it("never lets meta overwrite a reserved field", () => {
+    const line = formatLogLine({
+      level: 'info',
+      component: 'notification-monitor',
+      msg: 'hi',
+      meta: { level: 'pwned', msg: 'pwned', ts: 'pwned' },
+      now: FROZEN,
+    });
+    const record = JSON.parse(line);
+    expect(record.level).toBe('info');
+    expect(record.msg).toBe('hi');
+    expect(record.ts).toBe('2026-05-29T10:00:00.000Z');
+  });
+
+  it('serialises an Error in meta into a plain object', () => {
+    const err = new Error('boom');
+    const line = formatLogLine({
+      level: 'error',
+      component: 'notification-monitor',
+      msg: 'failed',
+      meta: { err },
+      now: FROZEN,
+    });
+    const record = JSON.parse(line);
+    expect(record.err).toEqual({
+      name: 'Error',
+      message: 'boom',
+      stack: expect.any(String),
+    });
+  });
+});
+
+describe('createLogger', () => {
+  it('writes one line per call with the right level', () => {
+    const written: string[] = [];
+    const logger = createLogger('notification-monitor', {
+      write: (line) => written.push(line),
+      now: () => FROZEN,
+    });
+
+    logger.info('listening', { port: 3001 });
+    logger.warn('client missing', { userId: 'u-1' });
+    logger.error('boom');
+
+    expect(written).toHaveLength(3);
+    expect(JSON.parse(written[0])).toMatchObject({ level: 'info', port: 3001 });
+    expect(JSON.parse(written[1])).toMatchObject({ level: 'warn', userId: 'u-1' });
+    expect(JSON.parse(written[2])).toMatchObject({ level: 'error', msg: 'boom' });
+  });
+
+  it('child() namespaces the component', () => {
+    const written: string[] = [];
+    const root = createLogger('agent', {
+      write: (line) => written.push(line),
+      now: () => FROZEN,
+    });
+    root.child('notifications').info('ready');
+    expect(JSON.parse(written[0]).component).toBe('agent.notifications');
+  });
+});

--- a/agent/logger.ts
+++ b/agent/logger.ts
@@ -1,0 +1,95 @@
+/**
+ * Structured logging for the notification server — Issue #146.
+ *
+ * Emits one JSON object per log call (newline-terminated) so logs can be
+ * ingested by any log aggregator without parsing free-form strings. Each line
+ * carries an ISO timestamp, level, component, message, and arbitrary
+ * structured metadata.
+ *
+ * `formatLogLine` is pure (no console / clock dependency) so it's trivial to
+ * unit-test; `createLogger` returns the friendly per-component API.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogRecord {
+  ts: string;
+  level: LogLevel;
+  component: string;
+  msg: string;
+  [key: string]: unknown;
+}
+
+export interface FormatLogLineArgs {
+  level: LogLevel;
+  component: string;
+  msg: string;
+  meta?: Record<string, unknown>;
+  now?: Date;
+}
+
+/** Produce a single JSON-encoded log record (no trailing newline). */
+export function formatLogLine(args: FormatLogLineArgs): string {
+  const ts = (args.now ?? new Date()).toISOString();
+  const record: LogRecord = {
+    ts,
+    level: args.level,
+    component: args.component,
+    msg: args.msg,
+  };
+  if (args.meta) {
+    for (const [k, v] of Object.entries(args.meta)) {
+      if (k in record) continue; // reserved keys win
+      record[k] = serialiseValue(v);
+    }
+  }
+  return JSON.stringify(record);
+}
+
+/** Convert non-JSON-safe values (Error, BigInt) into something stringifiable. */
+function serialiseValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  return value;
+}
+
+export interface Logger {
+  debug: (msg: string, meta?: Record<string, unknown>) => void;
+  info: (msg: string, meta?: Record<string, unknown>) => void;
+  warn: (msg: string, meta?: Record<string, unknown>) => void;
+  error: (msg: string, meta?: Record<string, unknown>) => void;
+  child: (component: string) => Logger;
+}
+
+export interface CreateLoggerOptions {
+  /** Output sink — defaults to stdout via console.log so tests can inject. */
+  write?: (line: string) => void;
+  /** Clock — injectable for deterministic tests. */
+  now?: () => Date;
+}
+
+/**
+ * Build a logger scoped to a component name. Levels are emitted unconditionally;
+ * filtering is left to the log shipper.
+ */
+export function createLogger(component: string, options: CreateLoggerOptions = {}): Logger {
+  const write = options.write ?? ((line: string) => process.stdout.write(line + '\n'));
+  const now = options.now ?? (() => new Date());
+
+  function emit(level: LogLevel, msg: string, meta?: Record<string, unknown>): void {
+    write(formatLogLine({ level, component, msg, meta, now: now() }));
+  }
+
+  return {
+    debug: (msg, meta) => emit('debug', msg, meta),
+    info: (msg, meta) => emit('info', msg, meta),
+    warn: (msg, meta) => emit('warn', msg, meta),
+    error: (msg, meta) => emit('error', msg, meta),
+    child: (childComponent) =>
+      createLogger(`${component}.${childComponent}`, { write, now }),
+  };
+}

--- a/agent/notification-monitor.ts
+++ b/agent/notification-monitor.ts
@@ -1,21 +1,27 @@
 /**
  * Notification Monitor Service
- * Runs the WebSocket server and monitors user goals for proactive notifications
+ * Runs the WebSocket server and monitors user goals for proactive notifications.
+ *
+ * Wiring (Issues #145, #146, #147):
+ *   - `loadAgentEnv` validates configuration up-front with a single multi-line
+ *     error instead of an ad-hoc `process.env.X` check.
+ *   - `createLogger` emits structured JSON log lines so operators can ingest
+ *     them without parsing free-form strings.
+ *   - `registerGracefulShutdown` collapses the previously-duplicated SIGTERM
+ *     and SIGINT blocks into a single, idempotent, timeout-capped handler.
  */
 
 import { createServer } from 'http';
 import { NotificationServer } from './websocket-server.js';
-import { projectGoalStatus, type GoalProjection } from './goal-projection.js';
+import { type GoalProjection } from './goal-projection.js';
 import { type UserGoal } from './notification-service.js';
 import { generateProactiveMessage } from './agent-service.js';
+import { loadAgentEnv } from './env.js';
+import { createLogger } from './logger.js';
+import { registerGracefulShutdown } from './graceful-shutdown.js';
 
-const PORT = parseInt(process.env.NOTIFICATION_PORT || '3001', 10);
-const API_KEY = process.env.GEMINI_API_KEY;
-
-if (!API_KEY) {
-  console.error('ERROR: GEMINI_API_KEY is not set in .env file');
-  process.exit(1);
-}
+const env = loadAgentEnv();
+const log = createLogger('notification-monitor');
 
 // Create HTTP server for WebSocket
 const httpServer = createServer();
@@ -48,11 +54,11 @@ async function triggerProactiveMessage(
         projection.requiredMonthlyContribution - goal.monthlyContribution
       ),
     },
-    API_KEY
+    env.GEMINI_API_KEY
   );
 
   // Send notification through WebSocket
-  const client = (notificationServer as any).clients?.get(goal.userId);
+  const client = (notificationServer as unknown as { clients?: Map<string, unknown> }).clients?.get(goal.userId);
   if (client) {
     notificationServer.broadcastMessage({
       type: 'agent-message',
@@ -70,6 +76,9 @@ async function triggerProactiveMessage(
         },
       },
     });
+    log.info('proactive message sent', { userId: goal.userId, shortfall: projection.shortfall });
+  } else {
+    log.warn('proactive message dropped: no active client', { userId: goal.userId });
   }
 }
 
@@ -77,36 +86,31 @@ async function triggerProactiveMessage(
  * Start monitoring service
  */
 function startMonitoring(): void {
-  httpServer.listen(PORT, () => {
-    console.log(`✅ Notification Server listening on ws://localhost:${PORT}`);
+  httpServer.listen(env.NOTIFICATION_PORT, () => {
+    log.info('notification server listening', { port: env.NOTIFICATION_PORT });
   });
 
-  // Graceful shutdown
-  process.on('SIGTERM', () => {
-    console.log('SIGTERM received, shutting down gracefully...');
-    notificationServer.shutdown();
-    httpServer.close(() => {
-      console.log('Server closed');
-      process.exit(0);
-    });
-  });
-
-  process.on('SIGINT', () => {
-    console.log('SIGINT received, shutting down gracefully...');
-    notificationServer.shutdown();
-    httpServer.close(() => {
-      console.log('Server closed');
-      process.exit(0);
-    });
+  registerGracefulShutdown({
+    logger: log,
+    handlers: [
+      async () => {
+        log.info('shutting down websocket server');
+        notificationServer.shutdown();
+      },
+      () =>
+        new Promise<void>((resolve) => {
+          httpServer.close(() => {
+            log.info('http server closed');
+            resolve();
+          });
+        }),
+    ],
   });
 }
 
 // Start the service
 startMonitoring();
+log.info('notification monitor ready');
 
-console.log(`
-╔══════════════════════════════════════╗
-║  Smasage Notification Monitor       ║
-║  Ready for Proactive Nudges  📊      ║
-╚══════════════════════════════════════╝
-`);
+// Export for tests / smoke verification.
+export { triggerProactiveMessage };


### PR DESCRIPTION
## Summary

Four assigned issues bundled into one PR. Each delivers a focused, well-tested core module (pure functions where possible, dependency-injected I/O) that the notification monitor wires up at the boundary.

- **#147 — Agent env validation module** (`agent/env.ts`): `validateEnv` is a pure validator that takes a `Record<string, string | undefined>` and returns either the typed `AgentEnv` or a list of human-readable error strings. `loadAgentEnv` wraps it and throws a single multi-line error so the operator can fix every misconfiguration in one pass. Covers `GEMINI_API_KEY` (required, non-empty) and `NOTIFICATION_PORT` (optional integer in 1–65535, defaults to 3001).
- **#146 — Structured logging** (`agent/logger.ts`): `formatLogLine` is a pure JSON-record formatter (ISO timestamp, level, component, msg + arbitrary metadata). Reserved keys can't be overwritten by user metadata, and `Error` / `BigInt` values are serialised safely. `createLogger(component, { write, now })` returns a `{ debug, info, warn, error, child }` API with injectable sink / clock so the notification monitor can swap the default stdout/clock for tests.
- **#145 — Graceful shutdown coverage** (`agent/graceful-shutdown.ts`): `registerGracefulShutdown({ logger, handlers, timeoutMs, signals, exit })` registers SIGTERM and SIGINT, runs the ordered cleanup list, is **idempotent** under repeat signals during shutdown, **continues past failing handlers** (logging each), and **hard-exits after a timeout** so a hanging cleanup can't wedge a container. `notification-monitor.ts` now uses this once instead of the two duplicated handler blocks.
- **#175 — Frontend npm audit high gate** (`.github/workflows/ci.yml`): added `npm audit --audit-level=high` to the `test-and-build-frontend` job, mirroring the existing agent gate from issue #176.

## Test plan

- [x] `jest agent/{env,logger,graceful-shutdown}.test.ts` — **20 / 20 new tests pass** (9 env + 6 logger + 5 graceful-shutdown).
- [x] Repo-level `jest` shows **49 tests pass**, no regressions in my workspace. One pre-existing failure (`frontend/src/utils/allocationParser.test.ts`) is JSX-config-related and untouched here.
- [x] `tsc --noEmit` in `agent/` is clean for the four new/changed files (env, logger, graceful-shutdown, notification-monitor).

## Pre-existing breakage (out of scope)

`agent/` `npm run build` reports 4 type errors in files this PR does **not** touch:

- `agent-service.ts:86` — `data` is of type `unknown`.
- `balance-reader.ts:22 / 43 / 64` — `Property 'invokeContract' does not exist on type 'Server'` (Stellar SDK drift).

These exist on a clean `main` checkout (the corresponding files are not in this branch's diff). Fixing them is unrelated SDK migration work. None of my new files contribute to the error count.

Closes #145
Closes #146
Closes #147
Closes #175