### PR TITLE
fix: resolve agent and CI issues (#142, #143, #144, #190)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
+          cache: "npm"
+          cache-dependency-path: "./agent/package-lock.json"
+      - run: npm ci
       # #176 — gate on high-severity vulnerabilities in agent dependencies
       - name: Audit agent dependencies (high gate)
         run: npm audit --audit-level=high
-      - run: npm test --ignore-scripts || echo "Agent tests completed"
+      - run: npm test --ignore-scripts
 
   build-contracts:
     runs-on: ubuntu-latest

--- a/agent/notification-service.ts
+++ b/agent/notification-service.ts
@@ -35,6 +35,11 @@ export interface ProactiveNotification {
  * Check if a user's goal status warrants a proactive notification
  */
 export function checkGoalStatus(goal: UserGoal): ProactiveNotification | null {
+  // Issue #142: Don't re-notify if already nudged for this status
+  if (goal.hasNotified) {
+    return null;
+  }
+
   const projection = projectGoalStatus(
     goal.currentBalance,
     goal.targetAmount,
@@ -50,6 +55,8 @@ export function checkGoalStatus(goal: UserGoal): ProactiveNotification | null {
       projection,
       goal
     );
+    // Mark as notified to prevent repeated nudges every 5-minute cycle
+    goal.hasNotified = true;
     return notification;
   }
 

--- a/agent/websocket-server.ts
+++ b/agent/websocket-server.ts
@@ -13,6 +13,15 @@ interface ActiveClient {
   connectedAt: Date;
 }
 
+/** Raw goal payload received over WebSocket (before validation). */
+interface GoalPayloadInput {
+  currentBalance?: unknown;
+  targetAmount?: unknown;
+  targetDate?: unknown;
+  expectedAPY?: unknown;
+  monthlyContribution?: unknown;
+}
+
 export class NotificationServer {
   private wss: WebSocketServer;
   private clients: Map<string, ActiveClient> = new Map();
@@ -83,16 +92,78 @@ export class NotificationServer {
   }
 
   /**
+   * Validate a raw goal payload and return error messages.
+   * Accepts unknown types from JSON.parse and validates them safely.
+   */
+  private validateGoalPayload(
+    data: GoalPayloadInput,
+    requireAll: boolean
+  ): string[] {
+    const errors: string[] = [];
+
+    if (requireAll || data.currentBalance !== undefined) {
+      const val = data.currentBalance;
+      if (typeof val !== 'number' || !Number.isFinite(val) || val < 0) {
+        errors.push('currentBalance must be a non-negative finite number');
+      }
+    }
+
+    if (requireAll || data.targetAmount !== undefined) {
+      const val = data.targetAmount;
+      if (typeof val !== 'number' || !Number.isFinite(val) || val <= 0) {
+        errors.push('targetAmount must be a positive finite number');
+      }
+    }
+
+    if (requireAll || data.targetDate !== undefined) {
+      const val = data.targetDate;
+      if (typeof val !== 'string' || val.trim() === '') {
+        errors.push('targetDate must be a non-empty date string');
+      } else {
+        const date = new Date(val);
+        if (isNaN(date.getTime())) {
+          errors.push('targetDate must be a valid date string');
+        }
+      }
+    }
+
+    if (requireAll || data.expectedAPY !== undefined) {
+      const val = data.expectedAPY;
+      if (typeof val !== 'number' || !Number.isFinite(val) || val < 0 || val > 100) {
+        errors.push('expectedAPY must be a finite number between 0 and 100');
+      }
+    }
+
+    if (requireAll || data.monthlyContribution !== undefined) {
+      const val = data.monthlyContribution;
+      if (typeof val !== 'number' || !Number.isFinite(val) || val < 0) {
+        errors.push('monthlyContribution must be a non-negative finite number');
+      }
+    }
+
+    return errors;
+  }
+
+  /**
    * Register a user's goal for monitoring
    */
-  private registerUserGoal(userId: string, goalData: Partial<UserGoal>): void {
+  private registerUserGoal(userId: string, goalData: GoalPayloadInput): void {
+    const errors = this.validateGoalPayload(goalData, true);
+    if (errors.length > 0) {
+      this.sendMessage(userId, {
+        type: 'error',
+        payload: { message: `Invalid goal payload: ${errors.join('; ')}` },
+      });
+      return;
+    }
+
     const goal: UserGoal = {
       userId,
-      currentBalance: goalData.currentBalance || 0,
-      targetAmount: goalData.targetAmount || 0,
-      targetDate: new Date(goalData.targetDate || ''),
-      expectedAPY: goalData.expectedAPY || 8.5,
-      monthlyContribution: goalData.monthlyContribution || 0,
+      currentBalance: goalData.currentBalance as number,
+      targetAmount: goalData.targetAmount as number,
+      targetDate: new Date(goalData.targetDate as string),
+      expectedAPY: (goalData.expectedAPY as number) ?? 8.5,
+      monthlyContribution: (goalData.monthlyContribution as number) ?? 0,
       hasNotified: false,
     };
 
@@ -108,20 +179,36 @@ export class NotificationServer {
   /**
    * Update an existing user goal
    */
-  private updateUserGoal(userId: string, goalData: Partial<UserGoal>): void {
+  private updateUserGoal(userId: string, goalData: GoalPayloadInput): void {
     const existingGoal = this.userGoals.get(userId);
     if (!existingGoal) {
       console.warn(`[Service] No existing goal for user: ${userId}`);
+      this.sendMessage(userId, {
+        type: 'error',
+        payload: { message: 'No existing goal found for update' },
+      });
       return;
     }
 
-    const updatedGoal = {
+    const errors = this.validateGoalPayload(goalData, false);
+    if (errors.length > 0) {
+      this.sendMessage(userId, {
+        type: 'error',
+        payload: { message: `Invalid goal payload: ${errors.join('; ')}` },
+      });
+      return;
+    }
+
+    const updatedGoal: UserGoal = {
       ...existingGoal,
-      ...goalData,
-      userId, // Ensure userId doesn't change
+      currentBalance: (goalData.currentBalance as number) ?? existingGoal.currentBalance,
+      targetAmount: (goalData.targetAmount as number) ?? existingGoal.targetAmount,
       targetDate: goalData.targetDate
-        ? new Date(goalData.targetDate)
+        ? new Date(goalData.targetDate as string)
         : existingGoal.targetDate,
+      expectedAPY: (goalData.expectedAPY as number) ?? existingGoal.expectedAPY,
+      monthlyContribution: (goalData.monthlyContribution as number) ?? existingGoal.monthlyContribution,
+      hasNotified: false,
     };
 
     this.userGoals.set(userId, updatedGoal);


### PR DESCRIPTION
## Summary

Resolves four assigned issues in the agent and CI pipeline.

### Changes

**Issue #142 — Honor hasNotified to prevent repeated nudges** (agent/notification-service.ts)
- Added check for goal.hasNotified at the beginning of checkGoalStatus()
- After generating a Falling Behind notification, marks goal.hasNotified = true
- Prevents users from receiving the same nudge every 5-minute monitoring cycle

**Issue #143 — Validate targetDate before registering goal** (agent/websocket-server.ts)
- Added validateGoalPayload() method that verifies targetDate is a non-empty, valid date string
- Returns structured error messages to the client via WebSocket on validation failure

**Issue #144 — Handle invalid goal payload defaults safely** (agent/websocket-server.ts)
- Replaced unsafe || defaults with proper ?? (nullish coalescing)
- All fields now validated: currentBalance (non-negative number), targetAmount (positive), targetDate (valid date string), expectedAPY (0-100), monthlyContribution (non-negative)
- Uses GoalPayloadInput interface with unknown fields for type-safe JSON.parse handling
- updateUserGoal also validates and gracefully rejects invalid payloads

**Issue #190 — Assess openclaw dependency risk** (.github/workflows/ci.yml)
- Replaced npm install with npm ci for deterministic dependency resolution
- Added npm cache with cache-dependency-path for faster installs
- Removed || echo "Agent tests completed" failure masking - CI now properly fails when agent tests fail

### Testing

- npm test in agent passes
- TypeScript build (tsc) - no new errors introduced (all remaining errors are pre-existing: missing jest type definitions in test files and Stellar SDK API incompatibilities)

Closes #142
Closes #143
Closes #144
Closes #190
