### PR TITLE
feat: agent type safety, notification alignment, contract migration, ci setup (#139 #140 #171 #179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@
 
    ```bash
    cd frontend
-   npm install
-   npm run dev
-   ```
+    npm ci
+    npm run dev
+    ```
 
 3. **Setup the Agent** (in a separate terminal):
 
-   ```bash
-   cd agent
-   npm install
-   npm start
+    ```bash
+    cd agent
+    npm ci
+    npm start
    ```
 
 4. **Build the Contracts**:

--- a/agent/websocket-server.ts
+++ b/agent/websocket-server.ts
@@ -44,6 +44,15 @@ interface GoalPayloadInput {
   monthlyContribution?: unknown;
 }
 
+/** Parsed and validated goal payload with proper types. */
+interface ValidatedGoalData {
+  currentBalance: number;
+  targetAmount: number;
+  targetDate: string;
+  expectedAPY: number;
+  monthlyContribution: number;
+}
+
 export class NotificationServer {
   private wss: WebSocketServer;
   private clients: Map<string, ActiveClient> = new Map();
@@ -201,6 +210,23 @@ export class NotificationServer {
   }
 
   /**
+   * Parse a validated goal payload into a typed object without `as` casts.
+   * Caller must ensure `validateGoalPayload` passed first.
+   */
+  private parseValidatedGoal(
+    data: GoalPayloadInput,
+    fallback: Partial<ValidatedGoalData>
+  ): ValidatedGoalData {
+    return {
+      currentBalance: typeof data.currentBalance === 'number' ? data.currentBalance : fallback.currentBalance!,
+      targetAmount: typeof data.targetAmount === 'number' ? data.targetAmount : fallback.targetAmount!,
+      targetDate: typeof data.targetDate === 'string' && data.targetDate.trim() !== '' ? data.targetDate : fallback.targetDate!,
+      expectedAPY: typeof data.expectedAPY === 'number' ? data.expectedAPY : fallback.expectedAPY!,
+      monthlyContribution: typeof data.monthlyContribution === 'number' ? data.monthlyContribution : fallback.monthlyContribution!,
+    };
+  }
+
+  /**
    * Register a user's goal for monitoring
    */
   private registerUserGoal(userId: string, goalData: GoalPayloadInput): void {
@@ -213,13 +239,21 @@ export class NotificationServer {
       return;
     }
 
+    const parsed = this.parseValidatedGoal(goalData, {
+      currentBalance: 0,
+      targetAmount: 0,
+      targetDate: '',
+      expectedAPY: 8.5,
+      monthlyContribution: 0,
+    });
+
     const goal: UserGoal = {
       userId,
-      currentBalance: goalData.currentBalance as number,
-      targetAmount: goalData.targetAmount as number,
-      targetDate: new Date(goalData.targetDate as string),
-      expectedAPY: (goalData.expectedAPY as number) ?? 8.5,
-      monthlyContribution: (goalData.monthlyContribution as number) ?? 0,
+      currentBalance: parsed.currentBalance,
+      targetAmount: parsed.targetAmount,
+      targetDate: new Date(parsed.targetDate),
+      expectedAPY: parsed.expectedAPY,
+      monthlyContribution: parsed.monthlyContribution,
       hasNotified: false,
     };
 
@@ -255,15 +289,21 @@ export class NotificationServer {
       return;
     }
 
+    const parsed = this.parseValidatedGoal(goalData, {
+      currentBalance: existingGoal.currentBalance,
+      targetAmount: existingGoal.targetAmount,
+      targetDate: existingGoal.targetDate.toISOString(),
+      expectedAPY: existingGoal.expectedAPY,
+      monthlyContribution: existingGoal.monthlyContribution,
+    });
+
     const updatedGoal: UserGoal = {
       ...existingGoal,
-      currentBalance: (goalData.currentBalance as number) ?? existingGoal.currentBalance,
-      targetAmount: (goalData.targetAmount as number) ?? existingGoal.targetAmount,
-      targetDate: goalData.targetDate
-        ? new Date(goalData.targetDate as string)
-        : existingGoal.targetDate,
-      expectedAPY: (goalData.expectedAPY as number) ?? existingGoal.expectedAPY,
-      monthlyContribution: (goalData.monthlyContribution as number) ?? existingGoal.monthlyContribution,
+      currentBalance: parsed.currentBalance,
+      targetAmount: parsed.targetAmount,
+      targetDate: new Date(parsed.targetDate),
+      expectedAPY: parsed.expectedAPY,
+      monthlyContribution: parsed.monthlyContribution,
       hasNotified: false,
     };
 

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -679,16 +679,16 @@ mod test {
     #[test]
     fn test_soroswap_integration() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
         
         // Register mocks
-        let router_id = env.register_contract(None, MockRouter);
-        let usdc_id = env.register_contract(None, MockToken);
-        let xlm_id = env.register_contract(None, MockToken);
+        let router_id = env.register(MockRouter, ());
+        let usdc_id = env.register(MockToken, ());
+        let xlm_id = env.register(MockToken, ());
 
         env.mock_all_auths();
 
@@ -706,20 +706,20 @@ mod test {
     #[test]
     fn test_withdraw_unwinds_blend_and_lp() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
-        let router = env.register_contract(None, MockRouter);
-        let usdc = env.register_contract(None, MockToken);
-        let xlm = env.register_contract(None, MockToken);
+        let router = env.register(MockRouter, ());
+        let usdc = env.register(MockToken, ());
+        let xlm = env.register(MockToken, ());
         env.mock_all_auths();
 
         client.initialize(&admin);
         client.initialize_soroswap(&admin, &router, &usdc, &xlm);
         
-        let blend_pool = env.register_contract(None, MockBlendPool);
+        let blend_pool = env.register(MockBlendPool, ());
         client.initialize_blend(&blend_pool, &usdc);
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool);
         blend_pool_client.initialize(&INDEX_RATE_PRECISION);
@@ -743,20 +743,20 @@ mod test {
     #[test]
     fn test_gold_allocation_tracking() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
         let user = Address::generate(&env);
-        let router = env.register_contract(None, MockRouter);
-        let usdc = env.register_contract(None, MockToken);
-        let xlm = env.register_contract(None, MockToken);
+        let router = env.register(MockRouter, ());
+        let usdc = env.register(MockToken, ());
+        let xlm = env.register(MockToken, ());
         env.mock_all_auths();
 
         client.initialize(&admin);
         client.initialize_soroswap(&admin, &router, &usdc, &xlm);
         
-        let blend_pool = env.register_contract(None, MockBlendPool);
+        let blend_pool = env.register(MockBlendPool, ());
         client.initialize_blend(&blend_pool, &usdc);
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool);
         blend_pool_client.initialize(&INDEX_RATE_PRECISION);
@@ -896,7 +896,7 @@ mod test {
     #[test]
     fn test_blend_initialization() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
 
         let blend_pool = Address::generate(&env);
@@ -917,13 +917,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -964,13 +964,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -1015,13 +1015,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -1062,13 +1062,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -1105,13 +1105,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -1149,13 +1149,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -1206,13 +1206,13 @@ mod test {
         let env = Env::default();
         
         // Register contracts
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         // Create addresses
@@ -1256,13 +1256,13 @@ mod test {
     #[should_panic(expected = "Amount must be greater than 0")]
     fn test_blend_supply_zero_amount() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
-        let token_id = env.register_contract(None, MockToken);
+        let token_id = env.register(MockToken, ());
         let token_client = MockTokenClient::new(&env, &token_id);
         
         let user = Address::generate(&env);
@@ -1284,10 +1284,10 @@ mod test {
     #[should_panic(expected = "No Blend position to withdraw")]
     fn test_blend_withdraw_no_position() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, SmasageYieldRouter);
+        let contract_id = env.register(SmasageYieldRouter, ());
         let client = SmasageYieldRouterClient::new(&env, &contract_id);
         
-        let blend_pool_id = env.register_contract(None, MockBlendPool);
+        let blend_pool_id = env.register(MockBlendPool, ());
         let blend_pool_client = MockBlendPoolClient::new(&env, &blend_pool_id);
         
         let user = Address::generate(&env);

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -44,11 +44,29 @@ export type OutgoingWsMessage = RegisterGoalMessage | UpdateGoalMessage | PingMe
 // Incoming payload shapes (server → client)
 // ---------------------------------------------------------------------------
 
+/** Payload for `connected` handshake. */
+export interface ConnectedPayload {
+  userId: string;
+  timestamp: string;
+}
+
+/** Payload for `error` messages. */
+export interface ErrorPayload {
+  message: string;
+}
+
 /** Payload for `agent-message` notifications. */
 export interface AgentMessagePayload {
+  sender: 'agent';
   text: string;
   proactive?: boolean;
   timestamp?: string;
+  projection?: {
+    status: string;
+    projectedValue: number;
+    shortfall?: number;
+    requiredMonthlyContribution?: number;
+  };
 }
 
 /** Payload for `goal-update` notifications (server-pushed goal status). */
@@ -59,43 +77,65 @@ export interface GoalUpdatePayload {
   status: 'on-track' | 'ahead' | 'falling-behind';
 }
 
+/** Payload for proactive notifications (server-pushed status alerts). */
+export interface ProactiveNotificationPayload {
+  type: 'falling-behind' | 'ahead' | 'on-track';
+  userId: string;
+  timestamp: string;
+  message: string;
+  suggestion?: string;
+  projection: {
+    status: string;
+    projectedValue: number;
+    shortfall?: number;
+    surplus?: number;
+    requiredMonthlyContribution?: number;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Discriminated union of all incoming notifications
 // ---------------------------------------------------------------------------
 
-interface ConnectedNotification {
+export interface ConnectedNotification {
   type: 'connected';
   userId?: string;
-  payload?: undefined;
+  payload: ConnectedPayload;
   timestamp?: string;
 }
 
-interface AgentMessageNotification {
+export interface ErrorNotification {
+  type: 'error';
+  userId?: string;
+  payload: ErrorPayload;
+  timestamp?: string;
+}
+
+export interface AgentMessageNotification {
   type: 'agent-message';
   userId?: string;
   payload: AgentMessagePayload;
   timestamp?: string;
 }
 
-interface GoalUpdateNotification {
+export interface GoalUpdateNotification {
   type: 'goal-update';
   userId?: string;
   payload: GoalUpdatePayload;
   timestamp?: string;
 }
 
-interface PongNotification {
-  type: 'pong';
+export interface ProactiveNotification {
+  type: 'notification';
   userId?: string;
-  payload?: undefined;
+  payload: ProactiveNotificationPayload;
   timestamp?: string;
 }
 
-/** Generic notification – used as the catch-all / unknown type. */
-interface GenericNotification {
-  type: 'notification';
+export interface PongNotification {
+  type: 'pong';
   userId?: string;
-  payload?: unknown;
+  payload?: undefined;
   timestamp?: string;
 }
 
@@ -105,14 +145,29 @@ interface GenericNotification {
  */
 export type IncomingNotification =
   | ConnectedNotification
+  | ErrorNotification
   | AgentMessageNotification
   | GoalUpdateNotification
-  | PongNotification
-  | GenericNotification;
+  | ProactiveNotification
+  | PongNotification;
 
 // ---------------------------------------------------------------------------
 // Type guards
 // ---------------------------------------------------------------------------
+
+/** Narrows a notification to `ConnectedNotification`. */
+export function isConnectedNotification(
+  n: IncomingNotification
+): n is ConnectedNotification {
+  return n.type === 'connected';
+}
+
+/** Narrows a notification to `ErrorNotification`. */
+export function isErrorNotification(
+  n: IncomingNotification
+): n is ErrorNotification {
+  return n.type === 'error';
+}
 
 /** Narrows a notification to `AgentMessageNotification`. */
 export function isAgentMessageNotification(
@@ -128,9 +183,16 @@ export function isGoalUpdateNotification(
   return n.type === 'goal-update';
 }
 
-/** Narrows a notification to the `connected` variant. */
-export function isConnectedNotification(
+/** Narrows a notification to `ProactiveNotification`. */
+export function isProactiveNotification(
   n: IncomingNotification
-): n is ConnectedNotification {
-  return n.type === 'connected';
+): n is ProactiveNotification {
+  return n.type === 'notification';
+}
+
+/** Narrows a notification to `PongNotification`. */
+export function isPongNotification(
+  n: IncomingNotification
+): n is PongNotification {
+  return n.type === 'pong';
 }


### PR DESCRIPTION
## Summary
Combined PR implementing 4 issues from the additional audit report.

---

### #139 [Agent 17] — Remove unsafe type assertions on private clients
- Added `parseValidatedGoal()` helper that narrows types via runtime `typeof` checks instead of `as number` / `as string` casts
- Replaced all unsafe casts in `registerUserGoal()` and `updateUserGoal()` with calls to the typed helper
- `GoalPayloadInput` (all `unknown` fields) is now consumed through a properly typed `ValidatedGoalData` interface
- `sendMessage()` and `broadcastMessage()` remain public — no need for external `as any` access

### #140 [Agent 18] — Align server notification type with frontend
- **Added** `ErrorNotification` type (was missing in frontend — server sends `{ type: 'error', payload: { message } }`)
- **Fixed** `ConnectedNotification.payload` shape to match server (`{ userId, timestamp }`)
- **Added** `ProactiveNotificationPayload` interface with full `type`, `projection`, etc.
- **Updated** `AgentMessagePayload` to include `sender: 'agent'` and `projection` fields
- **Added** type guards: `isErrorNotification`, `isProactiveNotification`, `isPongNotification`
- **Removed** catch-all `GenericNotification` — all incoming messages are now strictly typed

### #171 [Contract 24] — Migrate tests from `register_contract` to `register`
- Changed all **41 calls** from `env.register_contract(None, X)` to `env.register(X, ())`
- Uses the newer `soroban-sdk 22` API

### #179 [CI DevOps 07] — Use `npm ci` instead of `npm install`
- CI pipeline already used `npm ci` — no change needed there
- Updated **README.md** setup instructions from `npm install` to `npm ci` for consistency

## Files changed
| File | Change |
|------|--------|
| `agent/websocket-server.ts` | Added `ValidatedGoalData`, `parseValidatedGoal()`; removed `as` casts |
| `frontend/src/types/websocket.ts` | Full rewrite with proper types for all server messages |
| `contracts/src/lib.rs` | 41 `register_contract` → `register` calls |
| `README.md` | `npm install` → `npm ci` in setup instructions |

Closes #139
Closes #140
Closes #171
Closes #179