### PR TITLE
fix: #118-121 frontend fixes — chat state, notifications, deterministic colors, zero APY

### DIFF
--- a/frontend/src/app/components/ChatInterface.tsx
+++ b/frontend/src/app/components/ChatInterface.tsx
@@ -16,6 +16,7 @@ export interface ChatInterfaceProps {
   isTyping: boolean;
   onSendMessage: (message: string) => void;
   placeholder?: string;
+  isConnected?: boolean;
 }
 
 export function ChatInterface({
@@ -23,6 +24,7 @@ export function ChatInterface({
   isTyping,
   onSendMessage,
   placeholder = "Ask Smasage to adjust goals...",
+  isConnected = false,
 }: ChatInterfaceProps) {
   const [inputValue, setInputValue] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -54,16 +56,20 @@ export function ChatInterface({
               alignItems: "center",
               gap: "6px",
               fontSize: "0.85rem",
-              color: "var(--success)",
+              color: isConnected ? "var(--success)" : "var(--text-muted)",
             }}
           >
-            <CheckCircle2
-              size={12}
-              fill="var(--success)"
-              color="var(--bg-card)"
-              aria-hidden="true"
-            />{" "}
-            Online
+            {isConnected ? (
+              <CheckCircle2
+                size={12}
+                fill="var(--success)"
+                color="var(--bg-card)"
+                aria-hidden="true"
+              />
+            ) : (
+              <AlertCircle size={12} aria-hidden="true" />
+            )}{" "}
+            {isConnected ? "Online" : "Offline"}
           </div>
         </div>
       </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,6 +16,10 @@ import { useNotifications } from "../hooks/useNotifications";
 import {
   isAgentMessageNotification,
   isConnectedNotification,
+  isErrorNotification,
+  isGoalUpdateNotification,
+  isProactiveNotification,
+  isPongNotification,
 } from "../types/websocket";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { ConnectWalletButton } from "./components/ConnectWalletButton";
@@ -93,6 +97,24 @@ export default function Home() {
         if (parsedAllocations) {
           setAllocations(parsedAllocations);
         }
+      } else if (isProactiveNotification(notification)) {
+        const { message, suggestion } = notification.payload;
+        const agentMsg: ChatMessage = {
+          id: Date.now(),
+          sender: "agent",
+          text: suggestion ? `${message}\n\n💡 ${suggestion}` : message,
+          proactive: true,
+          timestamp: notification.timestamp,
+        };
+        setMessages((prev: ChatMessage[]) => [...prev, agentMsg]);
+        toast('💡 New suggestion from OpenClaw', { duration: 5000 });
+      } else if (isGoalUpdateNotification(notification)) {
+        console.log("[App] Goal update received", notification.payload);
+      } else if (isErrorNotification(notification)) {
+        console.error("[App] Server error:", notification.payload.message);
+        toast.error(notification.payload.message);
+      } else if (isPongNotification(notification)) {
+        console.log("[App] Pong received");
       }
     },
     onError: (error) => {
@@ -228,6 +250,7 @@ export default function Home() {
               messages={messages}
               isTyping={isTyping}
               onSendMessage={handleSendMessage}
+              isConnected={wsConnected}
             />
           </GlassPanel>
         </main>

--- a/frontend/src/utils/allocationParser.test.ts
+++ b/frontend/src/utils/allocationParser.test.ts
@@ -1,4 +1,4 @@
-import { parseAllocationsFromMessage, getDefaultAllocations } from './allocationParser';
+import { parseAllocationsFromMessage, getDefaultAllocations, getColorForAsset } from './allocationParser';
 
 describe('allocationParser Utils', () => {
   describe('parseAllocationsFromMessage', () => {
@@ -69,6 +69,27 @@ describe('allocationParser Utils', () => {
       const result = getDefaultAllocations();
       expect(result).toHaveLength(3);
       expect(result.reduce((sum, a) => sum + a.percentage, 0)).toBe(100);
+    });
+  });
+
+  describe('getColorForAsset determinism', () => {
+    it('returns the same color for an unknown asset at the same index', () => {
+      const color1 = getColorForAsset('UnknownAsset', 0);
+      const color2 = getColorForAsset('UnknownAsset', 0);
+      expect(color1).toBe(color2);
+    });
+
+    it('returns different colors for different indices', () => {
+      const color0 = getColorForAsset('UnknownAsset', 0);
+      const color1 = getColorForAsset('UnknownAsset', 1);
+      // They may or may not differ depending on palette size, but both must be valid hex strings
+      expect(color0).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(color1).toMatch(/^#[0-9a-f]{6}$/i);
+    });
+
+    it('unknown asset color is never random across repeated calls', () => {
+      const results = Array.from({ length: 10 }, () => getColorForAsset('Mystery', 2));
+      expect(new Set(results).size).toBe(1);
     });
   });
 });

--- a/frontend/src/utils/allocationParser.ts
+++ b/frontend/src/utils/allocationParser.ts
@@ -42,8 +42,8 @@ export function parseAllocationsFromMessage(
     // Skip very short descriptions (likely parsing error)
     if (assetName.length < 3) continue;
 
-    // Determine color based on asset name
-    const color = getColorForAsset(assetName);
+    // Determine color based on asset name (index for deterministic fallback)
+    const color = getColorForAsset(assetName, allocations.length);
 
     allocations.push({
       name: assetName,
@@ -72,9 +72,10 @@ export function parseAllocationsFromMessage(
 }
 
 /**
- * Determine color based on asset name keywords
+ * Determine color based on asset name keywords.
+ * For unknown assets, cycles deterministically by index to avoid non-determinism.
  */
-function getColorForAsset(assetName: string): string {
+export function getColorForAsset(assetName: string, index: number = 0): string {
   const lower = assetName.toLowerCase();
 
   if (lower.includes("blend")) return ALLOCATION_COLORS.blend;
@@ -85,9 +86,9 @@ function getColorForAsset(assetName: string): string {
   if (lower.includes("usdc")) return ALLOCATION_COLORS.usdc;
   if (lower.includes("xlm")) return ALLOCATION_COLORS.xlm;
 
-  // Cycle through colors for unknown assets
+  // Cycle through colors deterministically by index for unknown assets
   const colors = Object.values(ALLOCATION_COLORS);
-  return colors[Math.floor(Math.random() * colors.length)];
+  return colors[index % colors.length];
 }
 
 /**

--- a/frontend/src/utils/goalProjection.test.ts
+++ b/frontend/src/utils/goalProjection.test.ts
@@ -17,6 +17,18 @@ describe('goalProjection Utils', () => {
       // Total: 2361.27
       expect(result).toBeCloseTo(2361.27, 0);
     });
+
+    it('handles zero APY without NaN or Infinity', () => {
+      const result = calculateProjection(1000, 0, 1, 100);
+      expect(Number.isFinite(result)).toBe(true);
+      // 1000 principal + 100 * 12 * 1 contributions = 2200
+      expect(result).toBeCloseTo(2200, 0);
+    });
+
+    it('handles zero APY with no contributions', () => {
+      const result = calculateProjection(5000, 0, 2, 0);
+      expect(result).toBeCloseTo(5000, 0);
+    });
   });
 
   describe('getMonthsUntil', () => {

--- a/frontend/src/utils/goalProjection.ts
+++ b/frontend/src/utils/goalProjection.ts
@@ -21,7 +21,8 @@ export interface ProjectionResult {
 }
 
 /**
- * Calculate compound interest (client-side version)
+ * Calculate compound interest (client-side version).
+ * When apy is 0, falls back to simple linear accumulation to avoid division by zero.
  */
 export function calculateProjection(
   principal: number,
@@ -31,15 +32,18 @@ export function calculateProjection(
 ): number {
   const n = 12; // monthly compounding
   const r = apy / 100;
-  
-  const compoundAmount = principal * Math.pow((1 + r / n), n * years);
-  
-  let contributionAmount = 0;
-  if (monthlyContribution > 0) {
-    contributionAmount = monthlyContribution * 
-      (Math.pow((1 + r / n), n * years) - 1) / (r / n);
+
+  if (r === 0) {
+    // No yield: principal + flat contributions
+    return principal + monthlyContribution * n * years;
   }
-  
+
+  const compoundAmount = principal * Math.pow((1 + r / n), n * years);
+
+  const contributionAmount = monthlyContribution > 0
+    ? monthlyContribution * (Math.pow((1 + r / n), n * years) - 1) / (r / n)
+    : 0;
+
   return compoundAmount + contributionAmount;
 }
 


### PR DESCRIPTION
## Summary

Fixes four frontend audit issues.

### #118 — Show real chat online/offline state
- Added `isConnected?: boolean` prop to `ChatInterface`
- Status indicator shows **Online** ✓ or **Offline** based on live `wsConnected` from `page.tsx`

### #119 — Handle generic notification payloads in frontend
- Extended `onNotification` in `page.tsx` to handle all WS types: `notification`, `goal-update`, `error`, `pong`
- Proactive notifications surface as chat messages with toast; server errors show `toast.error`

### #120 — Make allocation parser deterministic
- Replaced `Math.random()` in `getColorForAsset` with index-based color cycling
- Exported `getColorForAsset` for direct testing
- Added determinism tests

### #121 — Add zero APY handling in frontend projection
- `calculateProjection` guards `r === 0` with linear fallback, avoiding `NaN`/`Infinity`
- Added zero-APY test cases

## Verification
- `npm run lint` — 0 errors, 4 pre-existing warnings (unchanged)
- `npm run build` — ✅ passes

Closes #118 
Closes #119
Closes #120 
Closes #121