### PR TITLE
fix(frontend): audit remediation for issues #110–#113

### DIFF
--- a/frontend/src/app/PortfolioChart.tsx
+++ b/frontend/src/app/PortfolioChart.tsx
@@ -92,23 +92,6 @@ export default function PortfolioChart({
                 slice.endAngle
               );
 
-              // Create donut by drawing inner circle cut-out
-              const pathWithDonut =
-                index === 0
-                  ? path.replace(
-                      'Z',
-                      ` A ${innerRadius} ${innerRadius} 0 0 0 ${slice.x1} ${slice.y1} Z`
-                    )
-                  : path.replace(
-                      'M ' + cx + ' ' + cy,
-                      `M ${slice.x2} ${slice.y2}`
-                    ).replace(
-                      'Z',
-                      ` A ${innerRadius} ${innerRadius} 0 0 ${slice.largeArc ? 0 : 1} ${
-                        slices[index - 1].x2
-                      } ${slices[index - 1].y2} Z`
-                    );
-
               return (
                 <g key={index}>
                   <path

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,10 +2,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { Activity } from "lucide-react";
 import { PortfolioStats } from "./components/PortfolioStats";
-import {
-  evaluateGoalStatus,
-  type GoalData,
-} from "../utils/goalProjection";
+import { evaluateGoalStatus } from "../utils/goalProjection";
 import PortfolioChart from "./PortfolioChart";
 import {
   parseAllocationsFromMessage,
@@ -63,7 +60,7 @@ export default function Home() {
       goalStatus: result.status,
       progress: result.progressPercentage,
     };
-  }, [goalData]);
+  }, []);
 
   // WebSocket notifications
   const { registerGoal } = useNotifications({
@@ -142,7 +139,7 @@ export default function Home() {
         monthlyContribution: goalData.monthlyContribution,
       });
     }
-  }, [wsConnected, registerGoal, goalData]);
+  }, [wsConnected, registerGoal]);
 
   const handleSendMessage = (message: string) => {
     const trimmed = message.trim();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,18 @@
-const { createDefaultPreset } = require("ts-jest");
-
-const tsJestTransformCfg = createDefaultPreset().transform;
-
-/** @type {import("jest").Config} **/
+/** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: "node",
+  roots: ["<rootDir>/frontend"],
+  testMatch: ["**/*.test.ts", "**/*.test.tsx"],
+  testPathIgnorePatterns: ["/node_modules/", "/.next/"],
   transform: {
-    ...tsJestTransformCfg,
+    "^.+\\.[jt]sx?$": [
+      "ts-jest",
+      {
+        tsconfig: "tsconfig.jest.json",
+      },
+    ],
+  },
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/frontend/src/$1",
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "jest": "^30.3.0",
-    "ts-jest": "^29.4.6"
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11"
   },
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"
-    "jest": "^30.4.2",
-    "ts-jest": "^29.4.11"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./frontend/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "isolatedModules": false
+  },
+  "include": ["frontend/**/*.ts", "frontend/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary

Addresses four frontend audit remediation items in a single scoped PR:

- **#110** — Fix root Jest JSX/TypeScript configuration: repair invalid root `package.json`, add `tsconfig.jest.json` extending the frontend config with `react-jsx`, and configure `ts-jest` transforms plus `@/` path mapping so the root test suite can compile frontend sources correctly.
- **#111** — Remove `goalData` from React hook dependency arrays (`useMemo` / `useEffect`); it is a module-level constant from `mockData` and does not change between renders.
- **#112** — Remove unused `GoalData` type import from `page.tsx`.
- **#113** — Remove unused `pathWithDonut` variable from `PortfolioChart.tsx` (chart rendering already uses `path`; no UI behavior change).

## Verification

- [x] `npm test` (root) — 3 suites, 40 tests passed
- [x] `npm run lint` (frontend) — no new warnings
- [x] `npm run build` (frontend) — successful

## Test plan

- [ ] CI `test-root` job passes on this PR
- [ ] CI `test-and-build-frontend` job passes
- [ ] Dashboard goal tracker and portfolio chart render as before on `/`

Closes #110
Closes #111
Closes #112
Closes #113