### PR TITLE
feat(ui): metric tile, status pill, motion card, empty/error states

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2224,3 +2224,98 @@ h2 {
   background: var(--success);
   box-shadow: 0 0 8px var(--success);
 }
+
+/* ── StatusPill (#91) ───────────────────────────────────────────── */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  user-select: none;
+}
+.status-pill__icon { font-size: 0.6rem; line-height: 1; }
+.status-pill--success { background: rgba(0,200,100,0.12); color: var(--success, #00c864); border: 1px solid rgba(0,200,100,0.25); }
+.status-pill--warning { background: rgba(255,180,0,0.12); color: #ffb400; border: 1px solid rgba(255,180,0,0.25); }
+.status-pill--error   { background: rgba(255,60,60,0.12); color: #ff4444; border: 1px solid rgba(255,60,60,0.25); }
+.status-pill--neutral { background: rgba(150,150,150,0.12); color: var(--text-muted, #888); border: 1px solid rgba(150,150,150,0.2); }
+
+/* ── MetricTile (#90) ───────────────────────────────────────────── */
+.metric-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.metric-tile__label {
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.metric-tile__value {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 1.4rem;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+.metric-tile__trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+.metric-tile__trend--up   { color: var(--success, #00c864); }
+.metric-tile__trend--down { color: #ff4444; }
+.metric-tile__trend--flat { color: var(--text-muted, #888); }
+.metric-tile__trend-label { font-family: 'JetBrains Mono', monospace; }
+
+/* Loading skeleton for MetricTile */
+.metric-tile--loading .metric-tile__label-skeleton,
+.metric-tile--loading .metric-tile__value-skeleton {
+  border-radius: 4px;
+  background: linear-gradient(90deg, rgba(255,255,255,0.05) 25%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.05) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+}
+.metric-tile--loading .metric-tile__label-skeleton { height: 0.75rem; width: 60%; margin-bottom: 0.25rem; }
+.metric-tile--loading .metric-tile__value-skeleton { height: 1.6rem; width: 80%; }
+
+/* ── EmptyState (#105) ──────────────────────────────────────────── */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--text-muted, #888);
+}
+.empty-state__icon { opacity: 0.4; margin-bottom: 0.25rem; }
+.empty-state__title { font-weight: 600; font-size: 0.9rem; color: var(--text-primary, #fff); margin: 0; }
+.empty-state__message { font-size: 0.8rem; margin: 0; max-width: 28ch; }
+.empty-state__action { margin-top: 0.75rem; }
+
+/* ── ErrorState (#105) ──────────────────────────────────────────── */
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+.error-state__icon { color: #ff4444; opacity: 0.7; margin-bottom: 0.25rem; }
+.error-state__title { font-weight: 600; font-size: 0.9rem; color: var(--text-primary, #fff); margin: 0; }
+.error-state__message { font-size: 0.8rem; color: var(--text-muted, #888); margin: 0; max-width: 28ch; }
+.error-state__retry { margin-top: 0.75rem; }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -23,6 +23,8 @@ import type { WalletConnectionStatus } from "../components/features/wallet/Conne
 import { ConnectWalletButton } from "../components/features/wallet/ConnectWalletButton";
 import { useFreighter } from "../hooks/useFreighter";
 import { ErrorBoundary } from "../components/feedback/ErrorBoundary";
+import { EmptyState } from "../components/feedback/EmptyState";
+import { ErrorState } from "../components/feedback/ErrorState";
 import {
   PortfolioStatsSkeleton,
   GoalTrackerSkeleton,
@@ -34,7 +36,7 @@ import { goalData, initialMessages } from "../config/mockData";
 import toast from 'react-hot-toast';
 import { GoalTracker } from "../components/features/portfolio/GoalTracker";
 import { GlassPanel } from "../components/layout/GlassPanel";
-import { Card } from "../components/primitives";
+import { Card, MotionCard } from "../components/primitives";
 import { Drawer } from "../components/features/wallet/Drawer";
 import { Network, Cpu, ShieldCheck, Zap } from "lucide-react";
 
@@ -84,6 +86,7 @@ export default function Home() {
   );
 
   const [isLoading, setIsLoading] = useState(true);
+  const [chartError, setChartError] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const walletStatus = useMemo<WalletConnectionStatus>(() => {
@@ -366,13 +369,24 @@ export default function Home() {
             )}
 
             <motion.div variants={itemVariants}>
-              <Card className="allocation-list" aria-labelledby="allocation-title">
+              <MotionCard className="allocation-list" aria-labelledby="allocation-title">
                 <h3 id="allocation-title" className="allocation-title">
                 <Activity size={18} aria-hidden="true" /> Active Strategy Routes
               </h3>
 
               {isLoading ? (
                 <PortfolioChartSkeleton />
+              ) : chartError ? (
+                <ErrorState
+                  title="Chart unavailable"
+                  message="Strategy allocation data failed to load."
+                  onRetry={() => setChartError(false)}
+                />
+              ) : allocations.length === 0 ? (
+                <EmptyState
+                  title="No allocations yet"
+                  message="Connect your wallet or ask the agent to build a strategy."
+                />
               ) : (
                 <div className="skeleton-fade-in">
                   <PortfolioChart
@@ -382,18 +396,25 @@ export default function Home() {
                   />
                 </div>
               )}
-              </Card>
+              </MotionCard>
             </motion.div>
           </GlassPanel>
 
           {/* Right Panel - Chat Agent */}
           <GlassPanel className="dashboard-chat" variants={itemVariants}>
-            <ChatInterface
-              messages={messages}
-              isTyping={isTyping}
-              onSendMessage={handleSendMessage}
-              isConnected={wsConnected}
-            />
+            {messages.length === 0 && !isTyping ? (
+              <EmptyState
+                title="No messages yet"
+                message="Ask Smasage to help manage your portfolio or set a goal."
+              />
+            ) : (
+              <ChatInterface
+                messages={messages}
+                isTyping={isTyping}
+                onSendMessage={handleSendMessage}
+                isConnected={wsConnected}
+              />
+            )}
           </GlassPanel>
         </motion.main>
       </>

--- a/frontend/src/components/features/portfolio/PortfolioStats.tsx
+++ b/frontend/src/components/features/portfolio/PortfolioStats.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import React from 'react';
-import { Wallet, TrendingUp } from 'lucide-react';
+import { MetricTile, StatusPill } from '../../primitives';
 
 export interface PortfolioStatsProps {
   totalValue: number;
   apy: number;
   valueChange: number;
+  loading?: boolean;
 }
 
 export const PortfolioStats: React.FC<PortfolioStatsProps> = ({
   totalValue,
   apy,
   valueChange,
+  loading = false,
 }) => {
   const formattedValue = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -22,29 +24,25 @@ export const PortfolioStats: React.FC<PortfolioStatsProps> = ({
   }).format(totalValue);
 
   const changeLabel = `${valueChange >= 0 ? '+' : ''}${valueChange.toFixed(1)}%`;
+  const trend = valueChange > 0 ? 'up' : valueChange < 0 ? 'down' : 'flat';
 
   return (
     <div className="stats-grid">
-      <div className="stat-card">
-        <div className="stat-label">
-          <Wallet size={16} color="var(--accent-primary)" />
-          Total Value
-        </div>
-        <div className="stat-value">
-          {formattedValue}
-          <span className="stat-sub">{changeLabel}</span>
-        </div>
-      </div>
-
+      <MetricTile
+        label="Total Value"
+        value={formattedValue}
+        trend={trend}
+        trendLabel={changeLabel}
+        loading={loading}
+        className="stat-card"
+      />
       <div className="stat-card secondary">
-        <div className="stat-label">
-          <TrendingUp size={16} color="var(--accent-secondary)" />
-          Est. Monthly APY
-        </div>
-        <div className="stat-value">
-          {apy.toFixed(1)}%
-          <span className="stat-sub">Active</span>
-        </div>
+        <MetricTile
+          label="Est. Monthly APY"
+          value={`${apy.toFixed(1)}%`}
+          loading={loading}
+        />
+        <StatusPill variant="success" label="Active" className="mt-1" />
       </div>
     </div>
   );

--- a/frontend/src/components/feedback/EmptyState.tsx
+++ b/frontend/src/components/feedback/EmptyState.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import { InboxIcon } from "lucide-react";
+
+export interface EmptyStateProps {
+  title?: string;
+  message?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  title = "Nothing here yet",
+  message = "Data will appear once it's available.",
+  action,
+  icon,
+  className,
+}: EmptyStateProps) {
+  const classes = ["empty-state", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes} role="status" aria-live="polite">
+      <div className="empty-state__icon" aria-hidden="true">
+        {icon ?? <InboxIcon size={32} />}
+      </div>
+      <p className="empty-state__title">{title}</p>
+      <p className="empty-state__message">{message}</p>
+      {action && (
+        <button
+          type="button"
+          className="empty-state__action btn btn--secondary"
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/feedback/ErrorState.tsx
+++ b/frontend/src/components/feedback/ErrorState.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+
+export interface ErrorStateProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  title = "Something went wrong",
+  message = "We couldn't load this data. Please try again.",
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  const classes = ["error-state", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes} role="alert" aria-live="assertive">
+      <div className="error-state__icon" aria-hidden="true">
+        <AlertTriangle size={32} />
+      </div>
+      <p className="error-state__title">{title}</p>
+      <p className="error-state__message">{message}</p>
+      {onRetry && (
+        <button
+          type="button"
+          className="error-state__retry btn btn--primary"
+          onClick={onRetry}
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/primitives/MetricTile.tsx
+++ b/frontend/src/components/primitives/MetricTile.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React from "react";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+
+export type TrendDirection = "up" | "down" | "flat";
+
+export interface MetricTileProps {
+  label: string;
+  value: string | number;
+  trend?: TrendDirection;
+  trendLabel?: string;
+  loading?: boolean;
+  className?: string;
+}
+
+const trendIcons: Record<TrendDirection, React.ReactNode> = {
+  up: <TrendingUp size={12} aria-hidden="true" />,
+  down: <TrendingDown size={12} aria-hidden="true" />,
+  flat: <Minus size={12} aria-hidden="true" />,
+};
+
+const trendClasses: Record<TrendDirection, string> = {
+  up: "metric-tile__trend metric-tile__trend--up",
+  down: "metric-tile__trend metric-tile__trend--down",
+  flat: "metric-tile__trend metric-tile__trend--flat",
+};
+
+export function MetricTile({
+  label,
+  value,
+  trend,
+  trendLabel,
+  loading = false,
+  className,
+}: MetricTileProps) {
+  const classes = ["metric-tile", loading && "metric-tile--loading", className]
+    .filter(Boolean)
+    .join(" ");
+
+  if (loading) {
+    return (
+      <div className={classes} aria-busy="true" aria-label={`Loading ${label}`}>
+        <div className="metric-tile__label-skeleton" />
+        <div className="metric-tile__value-skeleton" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes}>
+      <span className="metric-tile__label">{label}</span>
+      <span className="metric-tile__value" title={String(value)}>
+        {value}
+      </span>
+      {trend && (
+        <span
+          className={trendClasses[trend]}
+          aria-label={trendLabel ?? `Trend: ${trend}`}
+        >
+          {trendIcons[trend]}
+          {trendLabel && (
+            <span className="metric-tile__trend-label">{trendLabel}</span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/primitives/MotionCard.tsx
+++ b/frontend/src/components/primitives/MotionCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import { motion, useReducedMotion, type HTMLMotionProps } from "framer-motion";
+import { cardInteractionVariants, cardSpring } from "../../lib/motion";
+
+interface MotionCardProps extends Omit<HTMLMotionProps<"div">, "variants" | "initial" | "whileHover" | "whileTap" | "whileFocus" | "transition"> {
+  children: React.ReactNode;
+  /** Set to false for non-clickable tiles that should stay visually stable. */
+  interactive?: boolean;
+}
+
+export function MotionCard({
+  children,
+  interactive = true,
+  className,
+  ...props
+}: MotionCardProps) {
+  const prefersReduced = useReducedMotion();
+
+  if (!interactive || prefersReduced) {
+    return (
+      <motion.div
+        className={["bento-card", className].filter(Boolean).join(" ")}
+        {...props}
+      >
+        {children}
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div
+      className={["bento-card", className].filter(Boolean).join(" ")}
+      variants={cardInteractionVariants}
+      initial="rest"
+      whileHover="hover"
+      whileTap="tap"
+      whileFocus="hover"
+      transition={cardSpring}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/frontend/src/components/primitives/StatusPill.tsx
+++ b/frontend/src/components/primitives/StatusPill.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+
+export type StatusVariant = "success" | "warning" | "error" | "neutral";
+
+export interface StatusPillProps {
+  variant: StatusVariant;
+  label: string;
+  className?: string;
+}
+
+const variantClasses: Record<StatusVariant, string> = {
+  success: "status-pill status-pill--success",
+  warning: "status-pill status-pill--warning",
+  error: "status-pill status-pill--error",
+  neutral: "status-pill status-pill--neutral",
+};
+
+const variantIcons: Record<StatusVariant, string> = {
+  success: "●",
+  warning: "▲",
+  error: "✕",
+  neutral: "○",
+};
+
+export function StatusPill({ variant, label, className }: StatusPillProps) {
+  return (
+    <span
+      className={[variantClasses[variant], className].filter(Boolean).join(" ")}
+      role="status"
+      aria-label={`Status: ${label}`}
+    >
+      <span aria-hidden="true" className="status-pill__icon">
+        {variantIcons[variant]}
+      </span>
+      <span className="status-pill__label">{label}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/primitives/index.ts
+++ b/frontend/src/components/primitives/index.ts
@@ -1,2 +1,7 @@
 export * from './Button';
 export { Card } from './Card';
+export { StatusPill } from './StatusPill';
+export type { StatusPillProps, StatusVariant } from './StatusPill';
+export { MetricTile } from './MetricTile';
+export type { MetricTileProps, TrendDirection } from './MetricTile';
+export { MotionCard } from './MotionCard';

--- a/frontend/src/lib/motion.ts
+++ b/frontend/src/lib/motion.ts
@@ -1,0 +1,25 @@
+import type { Transition, Variants } from "framer-motion";
+
+/** Spring preset for tactile card interactions — not linear, feels physical. */
+export const cardSpring: Transition = {
+  type: "spring",
+  stiffness: 380,
+  damping: 28,
+  mass: 0.6,
+};
+
+/** Hover + press variants for clickable dashboard cards. */
+export const cardInteractionVariants: Variants = {
+  rest: { scale: 1, y: 0 },
+  hover: { scale: 1.018, y: -3, transition: cardSpring },
+  tap: { scale: 0.975, y: 0, transition: cardSpring },
+};
+
+/** Focus-visible styles mirror the hover affordance via CSS; this variant
+ *  keeps layout stable (no extra y shift) so focused-but-not-hovered cards
+ *  don't confuse sighted keyboard users.
+ */
+export const cardFocusVariants: Variants = {
+  rest: { scale: 1 },
+  focus: { scale: 1.012, transition: cardSpring },
+};


### PR DESCRIPTION
## Summary

- **MetricTile** (`#90`): typed `label/value/trend` props, monospace numeric styling, loading skeleton that holds layout with no shift
- **StatusPill** (`#91`): `success/warning/error/neutral` variants, `aria-label` on every instance, icon+text pairing avoids color-only signalling; used in `PortfolioStats` (APY active badge)
- **MotionCard** (`#93`): spring micro-interactions (hover lift + press scale) via shared `cardSpring` config in `src/lib/motion.ts`; respects `prefers-reduced-motion`; non-clickable tiles get `interactive={false}` and no animation
- **EmptyState + ErrorState** (`#105`): polished fallback states for chart, metrics, and chat panels; `ErrorState` has a retry action; `EmptyState` uses `role=status`, `ErrorState` uses `role=alert`; neither relies on color alone

## Changes

- `src/components/primitives/StatusPill.tsx` — new
- `src/components/primitives/MetricTile.tsx` — new
- `src/components/primitives/MotionCard.tsx` — new
- `src/lib/motion.ts` — shared spring config extracted
- `src/components/feedback/EmptyState.tsx` — new
- `src/components/feedback/ErrorState.tsx` — new
- `src/components/features/portfolio/PortfolioStats.tsx` — refactored to use `MetricTile` + `StatusPill`
- `src/app/page.tsx` — chart panel wrapped in `MotionCard`, empty/error states wired for chart and chat panels
- `src/app/globals.css` — design-system-aligned styles for all new components

## Test plan

- [ ] `npm run build` passes with no TypeScript errors (verified locally)
- [ ] Chart panel shows `EmptyState` when `allocations` is empty
- [ ] Chart panel shows `ErrorState` with retry button when `chartError` is true
- [ ] Chat panel shows `EmptyState` before any messages
- [ ] `MetricTile` loading skeleton does not shift layout on load
- [ ] `StatusPill` renders all four variants visually distinct without relying on color alone
- [ ] `MotionCard` hover/press animation plays on pointer devices; no animation with `prefers-reduced-motion: reduce`

closes #90
closes #91
closes #93
closes #105