### PR TITLE
feat: create shared frontend domain types module

### DIFF
--- a/frontend/src/components/features/chat/ChatInterface.tsx
+++ b/frontend/src/components/features/chat/ChatInterface.tsx
@@ -4,13 +4,8 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircle, Bot, CheckCircle2, Send } from "lucide-react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 
-export interface ChatMessage {
-  id: number;
-  sender: "agent" | "user";
-  text: string;
-  proactive?: boolean;
-  timestamp?: string;
-}
+export type { ChatMessage } from '../../../types/domain';
+import type { ChatMessage } from '../../../types/domain';
 
 export interface ChatInterfaceProps {
   messages: ChatMessage[];

--- a/frontend/src/types/domain.test.ts
+++ b/frontend/src/types/domain.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for shared frontend domain types (Issue #109)
+ *
+ * Verifies that type shapes are structurally correct and that consumers
+ * importing from domain.ts get the same types as those re-exported from
+ * the original utility modules.
+ */
+
+import type {
+  GoalData,
+  GoalStatus,
+  ServerGoalStatus,
+  ProjectionResult,
+  AssetAllocation,
+  ChatMessage,
+  ProactiveSuggestion,
+} from './domain';
+
+// Re-exports from legacy paths must remain available (backward compat).
+import type { GoalData as GoalDataFromUtil } from '../utils/goalProjection';
+import type { AssetAllocation as AssetAllocationFromUtil } from '../utils/chartUtils';
+import type { ProactiveSuggestion as ProactiveSuggestionFromUtil } from '../utils/suggestionHandler';
+
+// ---------------------------------------------------------------------------
+// Structural assignment checks (compile-time, caught at build by tsc)
+// ---------------------------------------------------------------------------
+
+// A valid GoalData value must satisfy the interface.
+const validGoal: GoalData = {
+  currentBalance: 12_450,
+  targetAmount: 18_000,
+  targetDate: '2026-08-01',
+  monthlyContribution: 500,
+  expectedAPY: 8.5,
+};
+
+// ProjectionResult must hold all required fields.
+const validProjection: ProjectionResult = {
+  status: 'On Track',
+  projectedValue: 19_200,
+  monthsRemaining: 14,
+  shortfall: 0,
+  surplus: 1_200,
+  progressPercentage: 69.2,
+};
+
+// AssetAllocation must hold name, percentage, and color.
+const validAllocation: AssetAllocation = {
+  name: 'Blend Protocol Yield (USDC)',
+  percentage: 60,
+  color: '#8b5cf6',
+};
+
+// ChatMessage must support both sender values and optional fields.
+const agentMsg: ChatMessage = {
+  id: 1,
+  sender: 'agent',
+  text: 'Welcome!',
+  proactive: true,
+  timestamp: '2026-06-01T10:00:00Z',
+};
+
+const userMsg: ChatMessage = { id: 2, sender: 'user', text: 'Hi' };
+
+// ProactiveSuggestion must support all three type variants.
+const contributionSuggestion: ProactiveSuggestion = {
+  type: 'contribution-increase',
+  currentContribution: 500,
+  suggestedContribution: 600,
+};
+
+const rebalanceSuggestion: ProactiveSuggestion = {
+  type: 'allocation-rebalance',
+  currentContribution: 500,
+  currentAllocation: { blend: 60, soroswap: 40 },
+  suggestedAllocation: { blend: 70, soroswap: 30 },
+};
+
+const bothSuggestion: ProactiveSuggestion = {
+  type: 'both',
+  currentContribution: 500,
+  suggestedContribution: 650,
+};
+
+// ---------------------------------------------------------------------------
+// Runtime shape tests
+// ---------------------------------------------------------------------------
+
+describe('domain types – GoalData', () => {
+  it('has all required numeric fields', () => {
+    expect(typeof validGoal.currentBalance).toBe('number');
+    expect(typeof validGoal.targetAmount).toBe('number');
+    expect(typeof validGoal.monthlyContribution).toBe('number');
+    expect(typeof validGoal.expectedAPY).toBe('number');
+  });
+
+  it('has a string targetDate', () => {
+    expect(typeof validGoal.targetDate).toBe('string');
+  });
+});
+
+describe('domain types – ProjectionResult', () => {
+  it('has valid GoalStatus values', () => {
+    const validStatuses: GoalStatus[] = ['On Track', 'Ahead', 'Falling Behind'];
+    expect(validStatuses).toContain(validProjection.status);
+  });
+
+  it('has non-negative shortfall and surplus', () => {
+    expect(validProjection.shortfall).toBeGreaterThanOrEqual(0);
+    expect(validProjection.surplus).toBeGreaterThanOrEqual(0);
+  });
+
+  it('progressPercentage is between 0 and 100', () => {
+    expect(validProjection.progressPercentage).toBeGreaterThanOrEqual(0);
+    expect(validProjection.progressPercentage).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('domain types – AssetAllocation', () => {
+  it('percentage is a number between 0 and 100', () => {
+    expect(validAllocation.percentage).toBeGreaterThanOrEqual(0);
+    expect(validAllocation.percentage).toBeLessThanOrEqual(100);
+  });
+
+  it('color is a non-empty string', () => {
+    expect(typeof validAllocation.color).toBe('string');
+    expect(validAllocation.color.length).toBeGreaterThan(0);
+  });
+});
+
+describe('domain types – ChatMessage', () => {
+  it('sender is "agent" or "user"', () => {
+    expect(['agent', 'user']).toContain(agentMsg.sender);
+    expect(['agent', 'user']).toContain(userMsg.sender);
+  });
+
+  it('optional fields are undefined when not provided', () => {
+    expect(userMsg.proactive).toBeUndefined();
+    expect(userMsg.timestamp).toBeUndefined();
+  });
+});
+
+describe('domain types – ProactiveSuggestion', () => {
+  it('supports contribution-increase type', () => {
+    expect(contributionSuggestion.type).toBe('contribution-increase');
+    expect(contributionSuggestion.suggestedContribution).toBeGreaterThan(
+      contributionSuggestion.currentContribution,
+    );
+  });
+
+  it('supports allocation-rebalance type', () => {
+    expect(rebalanceSuggestion.type).toBe('allocation-rebalance');
+    expect(rebalanceSuggestion.currentAllocation).toBeDefined();
+  });
+
+  it('supports both type', () => {
+    expect(bothSuggestion.type).toBe('both');
+  });
+});
+
+describe('domain types – ServerGoalStatus', () => {
+  it('accepts all valid server status strings', () => {
+    const statuses: ServerGoalStatus[] = ['on-track', 'ahead', 'falling-behind'];
+    expect(statuses).toHaveLength(3);
+    statuses.forEach((s) => expect(typeof s).toBe('string'));
+  });
+});
+
+describe('backward-compatibility re-exports', () => {
+  it('GoalData from goalProjection matches shape from domain', () => {
+    const fromUtil: GoalDataFromUtil = validGoal;
+    const fromDomain: GoalData = fromUtil;
+    expect(fromDomain).toStrictEqual(validGoal);
+  });
+
+  it('AssetAllocation from chartUtils matches shape from domain', () => {
+    const fromUtil: AssetAllocationFromUtil = validAllocation;
+    const fromDomain: AssetAllocation = fromUtil;
+    expect(fromDomain).toStrictEqual(validAllocation);
+  });
+
+  it('ProactiveSuggestion from suggestionHandler matches shape from domain', () => {
+    const fromUtil: ProactiveSuggestionFromUtil = contributionSuggestion;
+    const fromDomain: ProactiveSuggestion = fromUtil;
+    expect(fromDomain).toStrictEqual(contributionSuggestion);
+  });
+});

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared Frontend Domain Types – Issue #109
+ *
+ * Single source of truth for core business domain types used across the
+ * frontend. Utility modules and components import from here rather than
+ * defining their own copies.
+ */
+
+// ---------------------------------------------------------------------------
+// Goal domain
+// ---------------------------------------------------------------------------
+
+/** Goal-tracking status as evaluated client-side. */
+export type GoalStatus = 'On Track' | 'Ahead' | 'Falling Behind';
+
+/**
+ * Goal-tracking status string as pushed by the server.
+ * Distinct from the client-side GoalStatus to avoid accidental conflation.
+ */
+export type ServerGoalStatus = 'on-track' | 'ahead' | 'falling-behind';
+
+/** Input data required to evaluate or register a savings goal. */
+export interface GoalData {
+  currentBalance: number;
+  targetAmount: number;
+  /** ISO-8601 date string (e.g. "2026-08-01"). */
+  targetDate: string;
+  monthlyContribution: number;
+  expectedAPY: number;
+}
+
+/** Result of a client-side goal projection calculation. */
+export interface ProjectionResult {
+  status: GoalStatus;
+  projectedValue: number;
+  monthsRemaining: number;
+  shortfall: number;
+  surplus: number;
+  progressPercentage: number;
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio / allocation domain
+// ---------------------------------------------------------------------------
+
+/** A single asset-allocation slice used by charts and allocation parsers. */
+export interface AssetAllocation {
+  name: string;
+  /** Value between 0 and 100. */
+  percentage: number;
+  /** CSS-compatible color string (e.g. "#8b5cf6"). */
+  color: string;
+}
+
+// ---------------------------------------------------------------------------
+// Chat domain
+// ---------------------------------------------------------------------------
+
+/** A single message in the agent–user conversation. */
+export interface ChatMessage {
+  id: number;
+  sender: 'agent' | 'user';
+  text: string;
+  /** True when the message was generated without user prompting. */
+  proactive?: boolean;
+  /** ISO-8601 timestamp string. */
+  timestamp?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Suggestion domain
+// ---------------------------------------------------------------------------
+
+/** A proactive suggestion the agent offers to adjust the user's goal plan. */
+export interface ProactiveSuggestion {
+  type: 'contribution-increase' | 'allocation-rebalance' | 'both';
+  currentContribution: number;
+  suggestedContribution?: number;
+  currentAllocation?: Record<string, number>;
+  suggestedAllocation?: Record<string, number>;
+}

--- a/frontend/src/utils/chartUtils.ts
+++ b/frontend/src/utils/chartUtils.ts
@@ -3,11 +3,8 @@
  * No external charting dependencies - lightweight & customizable
  */
 
-export interface AssetAllocation {
-  name: string;
-  percentage: number;
-  color: string;
-}
+import type { AssetAllocation } from '../types/domain';
+export type { AssetAllocation };
 
 export interface PieSlice {
   startAngle: number;

--- a/frontend/src/utils/goalProjection.ts
+++ b/frontend/src/utils/goalProjection.ts
@@ -3,22 +3,8 @@
  * Client-side calculations for goal tracking and projections
  */
 
-export interface GoalData {
-  currentBalance: number;
-  targetAmount: number;
-  targetDate: string;
-  monthlyContribution: number;
-  expectedAPY: number;
-}
-
-export interface ProjectionResult {
-  status: 'On Track' | 'Ahead' | 'Falling Behind';
-  projectedValue: number;
-  monthsRemaining: number;
-  shortfall: number;
-  surplus: number;
-  progressPercentage: number;
-}
+import type { GoalData, ProjectionResult, GoalStatus } from '../types/domain';
+export type { GoalData, ProjectionResult, GoalStatus };
 
 /**
  * Calculate compound interest (client-side version).
@@ -78,7 +64,7 @@ export function evaluateGoalStatus(goal: GoalData): ProjectionResult {
   );
   
   const threshold = 0.95;
-  let status: 'On Track' | 'Ahead' | 'Falling Behind';
+  let status: GoalStatus;
   
   if (projectedValue >= goal.targetAmount * 1.05) {
     status = 'Ahead';

--- a/frontend/src/utils/suggestionHandler.ts
+++ b/frontend/src/utils/suggestionHandler.ts
@@ -3,13 +3,8 @@
  * Utilities for processing user acceptance of proactive suggestions
  */
 
-interface ProactiveSuggestion {
-  type: 'contribution-increase' | 'allocation-rebalance' | 'both';
-  currentContribution: number;
-  suggestedContribution?: number;
-  currentAllocation?: Record<string, number>;
-  suggestedAllocation?: Record<string, number>;
-}
+import type { ProactiveSuggestion } from '../types/domain';
+export type { ProactiveSuggestion };
 
 /**
  * Parse suggestion from proactive message


### PR DESCRIPTION
## Summary

- Creates `frontend/src/types/domain.ts` as the single source of truth for all core frontend business domain types
- Moves `GoalData`, `ProjectionResult`, `GoalStatus`, `AssetAllocation`, `ChatMessage`, and `ProactiveSuggestion` into the shared module
- Each original file (`goalProjection.ts`, `chartUtils.ts`, `suggestionHandler.ts`, `ChatInterface.tsx`) now imports from `domain.ts` and re-exports for full backward compatibility — no import paths broken
- Adds `frontend/src/types/domain.test.ts` with 16 new runtime shape tests (56 total, 0 tsc errors)

## Test plan

- [x] `npx jest` — 56 tests pass, 0 failures
- [x] `npx tsc -p tsconfig.jest.json --noEmit` — 0 type errors
- [x] All existing utility tests (chartUtils, allocationParser, goalProjection) continue passing unchanged

## Follow-up risks

- `npm run lint` has a pre-existing ESLint v10 / `eslint-plugin-react` incompatibility unrelated to this change
- `npm run build` requires network access to resolve `next@16.2.7` in this environment; types are verified clean via tsc

Closes #109
Closes #107
Closes #76