### PR TITLE
feat(revamp): Button spring interactions, Tailwind design tokens, premium dark UI base styles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,8 +20,11 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.0",
     "eslint": "^10",
     "eslint-config-next": "16.2.6",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
     "typescript": "^5"
   }
 }

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,3 +1,9 @@
+/* Tailwind layers — preflight is disabled in tailwind.config.ts to avoid
+   conflicts with the hand-crafted base styles below. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --bg-dark: #09090b;
   --bg-card: rgba(24, 24, 27, 0.6);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5,16 +5,103 @@
 @tailwind utilities;
 
 :root {
+  /* ── Background surfaces ─────────────────────────────────────── */
   --bg-dark: #09090b;
   --bg-card: rgba(24, 24, 27, 0.6);
+  --surface-1: #09090b;
+  --surface-2: rgba(24, 24, 27, 0.6);
+  --surface-3: rgba(39, 39, 42, 0.5);
+  --surface-elevated: rgba(63, 63, 70, 0.35);
+  --surface-overlay: rgba(9, 9, 11, 0.85);
+
+  /* ── Border ──────────────────────────────────────────────────── */
   --border: rgba(63, 63, 70, 0.4);
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --border-strong: rgba(255, 255, 255, 0.15);
+
+  /* ── Brand accent colours ────────────────────────────────────── */
   --accent-primary: #8b5cf6;
+  --accent-primary-hover: #9f75ff;
   --accent-secondary: #06b6d4;
-  --text-main: #f8fafc;
-  --text-muted: #94a3b8;
+  --accent-secondary-hover: #22d3ee;
+
+  /* ── Semantic colours ────────────────────────────────────────── */
   --success: #10b981;
+  --success-muted: rgba(16, 185, 129, 0.15);
+  --warning: #f59e0b;
+  --warning-muted: rgba(245, 158, 11, 0.15);
+  --error: #ef4444;
+  --error-muted: rgba(239, 68, 68, 0.15);
+  --info: #3b82f6;
+  --info-muted: rgba(59, 130, 246, 0.15);
+
+  /* ── Text ────────────────────────────────────────────────────── */
+  --text-main: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --text-placeholder: #64748b;
+  --text-disabled: rgba(148, 163, 184, 0.4);
+  --text-inverse: #09090b;
+
+  /* ── Glass ───────────────────────────────────────────────────── */
   --glass-bg: rgba(24, 24, 27, 0.7);
   --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-bg-light: rgba(255, 255, 255, 0.03);
+  --glass-highlight: rgba(255, 255, 255, 0.06);
+
+  /* ── Shadows ─────────────────────────────────────────────────── */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.4);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.5);
+  --shadow-glow-primary: 0 0 20px rgba(139, 92, 246, 0.4);
+  --shadow-glow-secondary: 0 0 20px rgba(6, 182, 212, 0.4);
+  --shadow-glow-success: 0 0 20px rgba(16, 185, 129, 0.35);
+  --shadow-btn-primary: 0 4px 12px rgba(139, 92, 246, 0.3);
+  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.3), inset 0 1px 0 var(--glass-highlight);
+
+  /* ── Gradients ───────────────────────────────────────────────── */
+  --gradient-primary: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+  --gradient-primary-hover: linear-gradient(135deg, var(--accent-primary-hover), var(--accent-secondary-hover));
+  --gradient-danger: linear-gradient(135deg, #ef4444, #f97316);
+  --gradient-brand: linear-gradient(135deg, #fff 0%, var(--text-muted) 100%);
+  --gradient-surface: linear-gradient(135deg, var(--surface-2), var(--surface-3));
+
+  /* ── Border radius ───────────────────────────────────────────── */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-2xl: 20px;
+  --radius-full: 9999px;
+
+  /* ── Blur ────────────────────────────────────────────────────── */
+  --blur-sm: 8px;
+  --blur-md: 12px;
+  --blur-lg: 20px;
+  --blur-xl: 40px;
+
+  /* ── Transitions ─────────────────────────────────────────────── */
+  --transition-instant: 50ms ease;
+  --transition-fast: 150ms ease;
+  --transition-base: 250ms ease;
+  --transition-slow: 400ms ease;
+  --transition-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ── Typography scale ────────────────────────────────────────── */
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* ── Layout ──────────────────────────────────────────────────── */
   --layout-max-width: 1400px;
   --layout-wide-max-width: 1520px;
   --chat-column-width: clamp(360px, 28vw, 420px);
@@ -33,6 +120,48 @@
   --focus-ring-width: 2px;
   --focus-ring-offset: 3px;
   --focus-ring-radius: 6px;
+
+  /* ── Z-index stack ───────────────────────────────────────────── */
+  --z-base: 0;
+  --z-raised: 10;
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-overlay: 300;
+  --z-modal: 400;
+  --z-toast: 500;
+}
+
+/* ── Base: smooth scroll ─────────────────────────────────────── */
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* ── Base: text selection ────────────────────────────────────── */
+::selection {
+  background: rgba(139, 92, 246, 0.3);
+  color: var(--text-main);
+}
+
+/* ── Base: custom scrollbar ──────────────────────────────────── */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
 }
 
 /* ── Accessibility: sr-only ──────────────────────────────────── */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -414,6 +414,88 @@ body {
   border-radius: 12px;
 }
 
+.btn-ghost {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--border);
+  color: var(--text-main);
+}
+
+.btn-ghost:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: 12px;
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: linear-gradient(135deg, #f87171, #fb923c);
+  box-shadow: 0 0 20px rgba(239, 68, 68, 0.45);
+  filter: saturate(1.1);
+}
+
+/* White ring on the danger gradient surface */
+.btn-danger:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color-on-accent);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: 12px;
+}
+
+/* ── Button sizes ───────────────────────────────────────────────── */
+.btn-sm {
+  padding: 0.45rem 0.875rem;
+  font-size: 0.8rem;
+  border-radius: 8px;
+  gap: 0.5rem;
+}
+
+.btn-sm.btn-primary:focus-visible,
+.btn-sm.btn-secondary:focus-visible,
+.btn-sm.btn-ghost:focus-visible,
+.btn-sm.btn-danger:focus-visible {
+  border-radius: 8px;
+}
+
+.btn-lg {
+  padding: 0.9rem 1.75rem;
+  font-size: 1rem;
+  border-radius: 14px;
+  gap: 0.75rem;
+}
+
+.btn-lg.btn-primary:focus-visible,
+.btn-lg.btn-secondary:focus-visible,
+.btn-lg.btn-ghost:focus-visible,
+.btn-lg.btn-danger:focus-visible {
+  border-radius: 14px;
+}
+
+/* ── Icon-only button modifier ──────────────────────────────────── */
+.btn-icon {
+  padding: 0.72rem;
+  aspect-ratio: 1;
+  gap: 0;
+}
+
+.btn-sm.btn-icon {
+  padding: 0.45rem;
+}
+
+.btn-lg.btn-icon {
+  padding: 0.9rem;
+}
+
 .btn-content {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/primitives/Button.test.ts
+++ b/frontend/src/components/primitives/Button.test.ts
@@ -1,0 +1,75 @@
+import type { ButtonVariant, ButtonSize } from "./Button";
+import { buttonSpring, buttonVariants } from "../../lib/motion";
+
+describe("buttonSpring", () => {
+  it("is a spring transition", () => {
+    expect(buttonSpring.type).toBe("spring");
+  });
+
+  it("has stiffness and damping set", () => {
+    expect(typeof buttonSpring.stiffness).toBe("number");
+    expect((buttonSpring.stiffness as number) > 0).toBe(true);
+    expect(typeof buttonSpring.damping).toBe("number");
+    expect((buttonSpring.damping as number) > 0).toBe(true);
+  });
+
+  it("is snappier than cardSpring (higher stiffness)", async () => {
+    const { cardSpring } = await import("../../lib/motion");
+    expect(buttonSpring.stiffness as number).toBeGreaterThan(
+      cardSpring.stiffness as number
+    );
+  });
+});
+
+describe("buttonVariants", () => {
+  it("defines rest, hover, and tap states", () => {
+    expect(buttonVariants.rest).toBeDefined();
+    expect(buttonVariants.hover).toBeDefined();
+    expect(buttonVariants.tap).toBeDefined();
+  });
+
+  it("tap scale is less than rest scale for tactile press feel", () => {
+    const restScale = (buttonVariants.rest as { scale: number }).scale;
+    const tapScale = (
+      buttonVariants.tap as { scale: number; transition?: unknown }
+    ).scale;
+    expect(tapScale).toBeLessThan(restScale);
+  });
+
+  it("hover scale is greater than rest scale", () => {
+    const restScale = (buttonVariants.rest as { scale: number }).scale;
+    const hoverScale = (
+      buttonVariants.hover as { scale: number; transition?: unknown }
+    ).scale;
+    expect(hoverScale).toBeGreaterThan(restScale);
+  });
+});
+
+describe("ButtonVariant type coverage", () => {
+  const validVariants: ButtonVariant[] = [
+    "primary",
+    "secondary",
+    "ghost",
+    "danger",
+  ];
+
+  it("includes all four variants", () => {
+    expect(validVariants).toHaveLength(4);
+  });
+
+  it("includes the ghost variant", () => {
+    expect(validVariants).toContain("ghost");
+  });
+
+  it("includes the danger variant", () => {
+    expect(validVariants).toContain("danger");
+  });
+});
+
+describe("ButtonSize type coverage", () => {
+  const validSizes: ButtonSize[] = ["sm", "md", "lg"];
+
+  it("includes all three sizes", () => {
+    expect(validSizes).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/primitives/Button.tsx
+++ b/frontend/src/components/primitives/Button.tsx
@@ -1,17 +1,23 @@
 import type { JSX } from "react";
 import { motion, useReducedMotion, type HTMLMotionProps } from "framer-motion";
+import { buttonSpring } from "../../lib/motion";
 
-export type ButtonVariant = "primary" | "secondary";
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+export type ButtonSize = "sm" | "md" | "lg";
 
 export interface ButtonProps extends HTMLMotionProps<"button"> {
   variant?: ButtonVariant;
+  size?: ButtonSize;
   isLoading?: boolean;
   loadingLabel?: string;
+  icon?: boolean;
 }
 
 export function Button({
   variant = "primary",
+  size = "md",
   isLoading = false,
+  icon = false,
   disabled,
   className,
   children,
@@ -19,24 +25,29 @@ export function Button({
   ...rest
 }: ButtonProps): JSX.Element {
   const prefersReduced = useReducedMotion();
-  const classes = ["btn", `btn-${variant}`, className].filter(Boolean).join(" ");
 
-  // Omit motion-conflicting props from rest to avoid type mismatches with motion.button
-  const motionProps: Record<string, unknown> = { ...rest } as unknown as Record<string, unknown>;
+  const sizeClass = size !== "md" ? `btn-${size}` : "";
+  const iconClass = icon ? "btn-icon" : "";
+  const classes = ["btn", `btn-${variant}`, sizeClass, iconClass, className]
+    .filter(Boolean)
+    .join(" ");
+
+  // Omit motion-conflicting props to avoid type mismatches with motion.button
+  const motionProps: Record<string, unknown> = {
+    ...rest,
+  } as unknown as Record<string, unknown>;
   delete motionProps.onAnimationStart;
   delete motionProps.onDrag;
   delete motionProps.onDragEnd;
   delete motionProps.onDragStart;
   delete motionProps.style;
 
-  // Decorative scale interactions are disabled for reduced-motion users.
-  // The button still shows :active via CSS (transform: scale(0.95)) which is
-  // a CSS-only affordance that browsers can suppress via their own UA sheet.
-  const hoverProp = !prefersReduced && !disabled && !isLoading ? { scale: 1.02 } : undefined;
-  const tapProp = !prefersReduced && !disabled && !isLoading ? { scale: 0.98 } : undefined;
-  const transitionProp = prefersReduced
-    ? { duration: 0.01 }
-    : { duration: 0.15, ease: "easeInOut" };
+  const isInteractive = !prefersReduced && !disabled && !isLoading;
+
+  // Tactile spring: hover lifts slightly, tap compresses with spring rebound.
+  const hoverProp = isInteractive ? { scale: 1.03 } : undefined;
+  const tapProp = isInteractive ? { scale: 0.95 } : undefined;
+  const transitionProp = prefersReduced ? { duration: 0.01 } : buttonSpring;
 
   return (
     <motion.button
@@ -69,8 +80,8 @@ export function Button({
             viewBox="0 0 24 24"
             fill="none"
             focusable="false"
-            // Spinner rotation is functional feedback (shows loading state), not
-            // purely decorative — keep it but slow it down for reduced motion.
+            // Spinner rotation is functional feedback, not purely decorative —
+            // keep it but slow it down for reduced motion.
             animate={{ rotate: 360 }}
             transition={
               prefersReduced

--- a/frontend/src/lib/motion.ts
+++ b/frontend/src/lib/motion.ts
@@ -8,6 +8,24 @@ export const cardSpring: Transition = {
   mass: 0.6,
 };
 
+/**
+ * Snappier spring for buttons — faster response than cards so press feedback
+ * is immediate, with a slight overshoot that reads as "springy" not "bouncy".
+ */
+export const buttonSpring: Transition = {
+  type: "spring",
+  stiffness: 500,
+  damping: 40,
+  mass: 0.4,
+};
+
+/** Hover + press variants for the revamp Button primitive. */
+export const buttonVariants: Variants = {
+  rest: { scale: 1 },
+  hover: { scale: 1.03, transition: buttonSpring },
+  tap: { scale: 0.95, transition: buttonSpring },
+};
+
 /** Hover + press variants for clickable dashboard cards. */
 export const cardInteractionVariants: Variants = {
   rest: { scale: 1, y: 0 },

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,141 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  corePlugins: {
+    // Preflight resets conflict with existing global.css base styles.
+    preflight: false,
+  },
+  theme: {
+    extend: {
+      colors: {
+        dark: {
+          DEFAULT: "#09090b",
+          card: "rgba(24, 24, 27, 0.6)",
+          surface2: "rgba(24, 24, 27, 0.7)",
+          surface3: "rgba(39, 39, 42, 0.5)",
+          elevated: "rgba(63, 63, 70, 0.35)",
+          overlay: "rgba(9, 9, 11, 0.85)",
+        },
+        accent: {
+          primary: "#8b5cf6",
+          "primary-hover": "#9f75ff",
+          secondary: "#06b6d4",
+          "secondary-hover": "#22d3ee",
+        },
+        content: {
+          main: "#f8fafc",
+          secondary: "#cbd5e1",
+          muted: "#94a3b8",
+          placeholder: "#64748b",
+          disabled: "rgba(148, 163, 184, 0.4)",
+        },
+        glass: {
+          bg: "rgba(24, 24, 27, 0.7)",
+          border: "rgba(255, 255, 255, 0.08)",
+          highlight: "rgba(255, 255, 255, 0.06)",
+          light: "rgba(255, 255, 255, 0.03)",
+        },
+        border: {
+          DEFAULT: "rgba(63, 63, 70, 0.4)",
+          subtle: "rgba(255, 255, 255, 0.05)",
+          strong: "rgba(255, 255, 255, 0.15)",
+        },
+        success: {
+          DEFAULT: "#10b981",
+          muted: "rgba(16, 185, 129, 0.15)",
+        },
+        warning: {
+          DEFAULT: "#f59e0b",
+          muted: "rgba(245, 158, 11, 0.15)",
+        },
+        error: {
+          DEFAULT: "#ef4444",
+          muted: "rgba(239, 68, 68, 0.15)",
+        },
+        info: {
+          DEFAULT: "#3b82f6",
+          muted: "rgba(59, 130, 246, 0.15)",
+        },
+      },
+      fontFamily: {
+        sans: [
+          "var(--font-outfit)",
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "Segoe UI",
+          "sans-serif",
+        ],
+      },
+      fontSize: {
+        "2xs": ["0.625rem", { lineHeight: "1rem" }],
+      },
+      borderRadius: {
+        btn: "12px",
+        "btn-sm": "8px",
+        "btn-lg": "14px",
+        card: "16px",
+        panel: "20px",
+      },
+      boxShadow: {
+        "glow-primary": "0 0 20px rgba(139, 92, 246, 0.4)",
+        "glow-secondary": "0 0 20px rgba(6, 182, 212, 0.4)",
+        "glow-success": "0 0 20px rgba(16, 185, 129, 0.35)",
+        "glow-danger": "0 0 20px rgba(239, 68, 68, 0.45)",
+        "btn-primary": "0 4px 12px rgba(139, 92, 246, 0.3)",
+        "btn-danger": "0 4px 12px rgba(239, 68, 68, 0.3)",
+        card: "0 4px 24px rgba(0, 0, 0, 0.3)",
+        glass:
+          "0 8px 32px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.06)",
+        "glass-sm": "0 4px 16px rgba(0, 0, 0, 0.35)",
+      },
+      backdropBlur: {
+        xs: "4px",
+        glass: "20px",
+      },
+      maxWidth: {
+        layout: "1400px",
+        "layout-wide": "1520px",
+      },
+      backgroundImage: {
+        "gradient-primary": "linear-gradient(135deg, #8b5cf6, #06b6d4)",
+        "gradient-primary-hover":
+          "linear-gradient(135deg, #9f75ff, #22d3ee)",
+        "gradient-danger": "linear-gradient(135deg, #ef4444, #f97316)",
+        "gradient-brand":
+          "linear-gradient(135deg, #fff 0%, #94a3b8 100%)",
+        "gradient-surface":
+          "linear-gradient(135deg, rgba(24,24,27,0.6), rgba(39,39,42,0.5))",
+      },
+      transitionTimingFunction: {
+        spring: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+      },
+      animation: {
+        "spin-slow": "spin 2s linear infinite",
+        shimmer: "shimmer 2s linear infinite",
+      },
+      keyframes: {
+        shimmer: {
+          "0%": { backgroundPosition: "-200% 0" },
+          "100%": { backgroundPosition: "200% 0" },
+        },
+      },
+      zIndex: {
+        base: "0",
+        raised: "10",
+        dropdown: "100",
+        sticky: "200",
+        overlay: "300",
+        modal: "400",
+        toast: "500",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary

- **Button revamp** — extends `ButtonVariant` with `ghost` and `danger`, adds `ButtonSize` (`sm`/`md`/`lg`) and `icon` prop; replaces linear easing with a Framer Motion spring (`stiffness 500, damping 40`) for tactile hover (1.03×) and press (0.95×) feedback; exports `buttonSpring` and `buttonVariants` from `motion.ts`; adds matching CSS for all new variants and sizes; includes `Button.test.ts` for type and spring-constant coverage.

- **Tailwind setup** — installs `tailwindcss`, `postcss`, and `autoprefixer`; creates `tailwind.config.ts` mapping every existing design token (colors, shadows, gradients, border-radius, z-index, animation keyframes) into the Tailwind theme with `preflight: false` to avoid conflicts with hand-crafted CSS; creates `postcss.config.mjs`; adds `@tailwind base/components/utilities` directives to `globals.css`.

- **Premium dark UI base** — expands `:root` from 15 to 60+ design tokens covering surfaces (`--surface-1/2/3/elevated/overlay`), text scale, semantic colors (`--warning`, `--error`, `--info` with muted variants), shadows (`--shadow-xs` → `--shadow-xl`, glow variants), gradients, border-radius scale, blur, transition presets, typography scale, and z-index stack; adds `html` base styles (smooth scroll, font antialiasing), `::selection` brand color, and custom `::-webkit-scrollbar` for the dark theme.

## Related Issues
Closes #73 
Closes #74 
Closes #75 