### PR TITLE
feat: implement Modal, Tooltip, DashboardLayout, and BentoDashboard

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -127,6 +127,7 @@
   --z-dropdown: 100;
   --z-sticky: 200;
   --z-overlay: 300;
+  --z-tooltip: 350;
   --z-modal: 400;
   --z-toast: 500;
 }
@@ -2184,6 +2185,13 @@ h2 {
   margin-bottom: 2rem;
 }
 
+.modal-body {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
 .modal-actions {
   display: flex;
   flex-direction: column;
@@ -2765,5 +2773,149 @@ h2 {
 
   .chat-input-container input::placeholder {
     transition: none;
+  }
+}
+
+/* ── Tooltip (Issue #78) ─────────────────────────────────────── */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-anchor {
+  position: absolute;
+  z-index: var(--z-tooltip);
+  pointer-events: none;
+}
+
+.tooltip-anchor.tooltip-top {
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip-anchor.tooltip-bottom {
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip-anchor.tooltip-left {
+  right: calc(100% + 6px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.tooltip-anchor.tooltip-right {
+  left: calc(100% + 6px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.tooltip-content {
+  background: rgba(24, 24, 27, 0.92);
+  backdrop-filter: blur(var(--blur-md));
+  -webkit-backdrop-filter: blur(var(--blur-md));
+  border: 1px solid var(--glass-border);
+  color: var(--text-main);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  max-width: min(14rem, calc(100vw - 2rem));
+  word-break: break-word;
+  white-space: normal;
+}
+
+/* ── Dashboard Layout shell (Issue #79) ──────────────────────── */
+.dashboard-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--bg-dark);
+}
+
+.dashboard-layout-main {
+  flex: 1;
+  width: 100%;
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+  padding: 2rem;
+  min-width: 0;
+}
+
+@media (min-width: 1440px) {
+  .dashboard-layout-main {
+    max-width: var(--layout-wide-max-width);
+    padding: 2.25rem 2.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-layout-main {
+    padding: 1rem;
+  }
+}
+
+/* ── Bento Dashboard grid (Issue #80) ────────────────────────── */
+.bento-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) var(--chat-column-width);
+  grid-template-areas:
+    "metrics metrics agent"
+    "goal    chart   agent"
+    "wallet  status  agent";
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.bento-area-metrics { grid-area: metrics; }
+.bento-area-goal    { grid-area: goal; }
+.bento-area-chart   { grid-area: chart; }
+.bento-area-wallet  { grid-area: wallet; }
+.bento-area-status  { grid-area: status; }
+
+.bento-area-agent {
+  grid-area: agent;
+  min-height: 0;
+  max-height: calc(100vh - 7rem);
+  position: sticky;
+  top: 5.5rem;
+  align-self: start;
+}
+
+/* Tablet: 2-column, agent spans full width at bottom */
+@media (max-width: 1024px) {
+  .bento-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "metrics metrics"
+      "goal    chart"
+      "wallet  status"
+      "agent   agent";
+  }
+
+  .bento-area-agent {
+    position: static;
+    max-height: 36rem;
+  }
+}
+
+/* Mobile: single column */
+@media (max-width: 640px) {
+  .bento-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "metrics"
+      "goal"
+      "chart"
+      "wallet"
+      "status"
+      "agent";
+  }
+
+  .bento-area-agent {
+    max-height: 28rem;
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -36,19 +36,14 @@ import { goalData, initialMessages } from "../config/mockData";
 import toast from 'react-hot-toast';
 import { GoalTracker } from "../components/features/portfolio/GoalTracker";
 import { GlassPanel } from "../components/layout/GlassPanel";
-import { Card, MotionCard } from "../components/primitives";
+import { MotionCard } from "../components/primitives";
 import { Drawer } from "../components/features/wallet/Drawer";
 import { Network, Cpu, ShieldCheck, Zap } from "lucide-react";
-
-import { motion, useReducedMotion } from "framer-motion";
-import { makeContainerVariants, makeEntranceVariants } from "../lib/motion";
+import { WsStatusIndicator } from "../components/layout/WsStatusIndicator";
+import { DashboardLayout } from "../components/layout/DashboardLayout";
+import { BentoDashboard } from "../components/features/dashboard";
 
 export default function Home() {
-  const prefersReduced = useReducedMotion();
-
-  const containerVariants = makeContainerVariants(!!prefersReduced);
-  const itemVariants = makeEntranceVariants(!!prefersReduced);
-
   const {
     publicKey,
     connect,
@@ -205,200 +200,217 @@ export default function Home() {
     }, 1800);
   };
 
+  const metricsSlot = isLoading ? (
+    <PortfolioStatsSkeleton />
+  ) : (
+    <div className="skeleton-fade-in">
+      <PortfolioStats
+        totalValue={goalData.currentBalance}
+        apy={goalData.expectedAPY}
+        valueChange={12.4}
+      />
+    </div>
+  );
+
+  const goalSlot = isLoading ? (
+    <GoalTrackerSkeleton />
+  ) : (
+    <GoalTracker
+      goalName="European Vacation"
+      targetAmount={goalData.targetAmount}
+      targetDate={goalData.targetDate}
+      status={goalStatus}
+      progressPercentage={progress}
+      remainingAmount={goalData.targetAmount - goalData.currentBalance}
+    />
+  );
+
+  const chartSlot = (
+    <MotionCard className="allocation-list" aria-labelledby="allocation-title">
+      <h3 id="allocation-title" className="allocation-title">
+        <Activity size={18} aria-hidden="true" /> Active Strategy Routes
+      </h3>
+      {isLoading ? (
+        <PortfolioChartSkeleton />
+      ) : chartError ? (
+        <ErrorState
+          title="Chart unavailable"
+          message="Strategy allocation data failed to load."
+          onRetry={() => setChartError(false)}
+        />
+      ) : allocations.length === 0 ? (
+        <EmptyState
+          title="No allocations yet"
+          message="Connect your wallet or ask the agent to build a strategy."
+        />
+      ) : (
+        <div className="skeleton-fade-in">
+          <PortfolioChart
+            allocations={allocations}
+            showLegend={true}
+            animated={true}
+          />
+        </div>
+      )}
+    </MotionCard>
+  );
+
+  const walletSlot = (
+    <GlassPanel className="bento-card">
+      <ConnectWalletButton
+        onClick={connect}
+        publicKey={publicKey || undefined}
+        isConnecting={isConnecting}
+      />
+      {publicKey && (
+        <p className="text-muted" style={{ fontSize: 'var(--text-xs)', marginTop: '0.5rem', wordBreak: 'break-all' }}>
+          {publicKey.slice(0, 8)}…{publicKey.slice(-4)}
+        </p>
+      )}
+    </GlassPanel>
+  );
+
+  const statusSlot = (
+    <GlassPanel className="bento-card">
+      <p className="text-muted" style={{ fontSize: 'var(--text-xs)', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        Network
+      </p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <WsStatusIndicator connected={wsConnected} />
+        <span style={{ fontSize: 'var(--text-sm)', color: wsConnected ? 'var(--success)' : 'var(--text-muted)' }}>
+          {wsConnected ? 'Connected' : 'Connecting…'}
+        </span>
+      </div>
+    </GlassPanel>
+  );
+
+  const agentSlot = messages.length === 0 && !isTyping ? (
+    <GlassPanel style={{ height: '100%' }}>
+      <EmptyState
+        title="No messages yet"
+        message="Ask Smasage to help manage your portfolio or set a goal."
+      />
+    </GlassPanel>
+  ) : (
+    <ChatInterface
+      messages={messages}
+      isTyping={isTyping}
+      onSendMessage={handleSendMessage}
+      isConnected={wsConnected}
+    />
+  );
+
   return (
     <ErrorBoundary fallbackMessage="The dashboard failed to load. Please try again.">
-      <>
-        <DashboardHeader
-          webSocketStatus={webSocketStatus}
-          walletStatus={walletStatus}
-          publicKey={publicKey}
-          onOpenSettings={() => setIsDrawerOpen(true)}
-        >
-          <ConnectWalletButton
-            onClick={connect}
-            publicKey={publicKey || undefined}
-            isConnecting={isConnecting}
-          />
-        </DashboardHeader>
-
-        <Drawer
-          isOpen={isDrawerOpen}
-          onClose={() => setIsDrawerOpen(false)}
-          title="Technical Details"
-        >
-          <div className="tech-section">
-            <h3 className="tech-section-title">
-              <Network size={14} /> Connectivity
-            </h3>
-            <div className="tech-grid">
-              <div className="tech-item">
-                <div className="tech-label">Notification Service</div>
-                <div className="tech-status">
-                  <span className={`status-dot ${wsConnected ? 'online' : ''}`} />
-                  {wsConnected ? 'Connected (WebSocket)' : 'Connecting...'}
-                </div>
-              </div>
-              <div className="tech-item">
-                <div className="tech-label">Stellar RPC (Soroban)</div>
-                <div className="tech-status">
-                  <span className="status-dot online" />
-                  Mainnet - 🚀 Horizon
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="tech-section">
-            <h3 className="tech-section-title">
-              <ShieldCheck size={14} /> Wallet & Security
-            </h3>
-            <div className="tech-grid">
-              <div className="tech-item">
-                <div className="tech-label">Public Key</div>
-                <div className="tech-value">{publicKey || 'Not connected'}</div>
-              </div>
-              <div className="tech-item">
-                <div className="tech-label">Provider</div>
-                <div className="tech-value">Freighter Wallet</div>
-              </div>
-            </div>
-          </div>
-
-          <div className="tech-section">
-            <h3 className="tech-section-title">
-              <Cpu size={14} /> AI Context
-            </h3>
-            <div className="tech-grid">
-              <div className="tech-item">
-                <div className="tech-label">Active Model</div>
-                <div className="tech-value">OpenClaw (Gemini 1.5 Pro)</div>
-              </div>
-              <div className="tech-item">
-                <div className="tech-label">Knowledge Cutoff</div>
-                <div className="tech-value">May 2024</div>
-              </div>
-            </div>
-          </div>
-
-          <div className="tech-section">
-            <h3 className="tech-section-title">
-              <Zap size={14} /> Protocol Routing
-            </h3>
-            <div className="tech-grid">
-              <div className="tech-item">
-                <div className="tech-label">Primary Aggregator</div>
-                <div className="tech-value">Smasage V1</div>
-              </div>
-              <div className="tech-item">
-                <div className="tech-label">Supported Protocols</div>
-                <div className="tech-value">Blend, Soroswap, Aquarius</div>
-              </div>
-            </div>
-          </div>
-        </Drawer>
-
-        <WalletModalTest
-          isOpen={showInstallModal}
-          onClose={() => setShowInstallModal(false)}
-        />
-        <motion.main
-          className="app-container"
-          aria-label="Portfolio dashboard"
-          variants={containerVariants}
-          initial="hidden"
-          animate="visible"
-        >
-          {/* Left Panel - Dashboard */}
-          <GlassPanel className="dashboard-portfolio" variants={itemVariants}>
-            <motion.h1 variants={itemVariants}>Smasage Portfolio</motion.h1>
-            <motion.p
-              className="text-muted portfolio-subtitle"
-              variants={itemVariants}
+      <DashboardLayout
+        header={
+          <DashboardHeader
+            webSocketStatus={webSocketStatus}
+            walletStatus={walletStatus}
+            publicKey={publicKey}
+            onOpenSettings={() => setIsDrawerOpen(true)}
+          >
+            <ConnectWalletButton
+              onClick={connect}
+              publicKey={publicKey || undefined}
+              isConnecting={isConnecting}
+            />
+          </DashboardHeader>
+        }
+        overlays={
+          <>
+            <Drawer
+              isOpen={isDrawerOpen}
+              onClose={() => setIsDrawerOpen(false)}
+              title="Technical Details"
             >
-              Real-time on-chain tracking • Stellar Mainnet 🚀
-            </motion.p>
-
-            {isLoading ? (
-              <motion.div variants={itemVariants}>
-                <PortfolioStatsSkeleton />
-              </motion.div>
-            ) : (
-              <motion.div className="skeleton-fade-in" variants={itemVariants}>
-                <PortfolioStats
-                  totalValue={goalData.currentBalance}
-                  apy={goalData.expectedAPY}
-                  valueChange={12.4}
-                />
-              </motion.div>
-            )}
-
-            {isLoading ? (
-              <motion.div variants={itemVariants}>
-                <GoalTrackerSkeleton />
-              </motion.div>
-            ) : (
-              <motion.div variants={itemVariants}>
-                <GoalTracker
-                  goalName="European Vacation"
-                  targetAmount={goalData.targetAmount}
-                  targetDate={goalData.targetDate}
-                  status={goalStatus}
-                  progressPercentage={progress}
-                  remainingAmount={goalData.targetAmount - goalData.currentBalance}
-                />
-              </motion.div>
-            )}
-
-            <motion.div variants={itemVariants}>
-              <MotionCard className="allocation-list" aria-labelledby="allocation-title">
-                <h3 id="allocation-title" className="allocation-title">
-                <Activity size={18} aria-hidden="true" /> Active Strategy Routes
-              </h3>
-
-              {isLoading ? (
-                <PortfolioChartSkeleton />
-              ) : chartError ? (
-                <ErrorState
-                  title="Chart unavailable"
-                  message="Strategy allocation data failed to load."
-                  onRetry={() => setChartError(false)}
-                />
-              ) : allocations.length === 0 ? (
-                <EmptyState
-                  title="No allocations yet"
-                  message="Connect your wallet or ask the agent to build a strategy."
-                />
-              ) : (
-                <div className="skeleton-fade-in">
-                  <PortfolioChart
-                    allocations={allocations}
-                    showLegend={true}
-                    animated={true}
-                  />
+              <div className="tech-section">
+                <h3 className="tech-section-title">
+                  <Network size={14} /> Connectivity
+                </h3>
+                <div className="tech-grid">
+                  <div className="tech-item">
+                    <div className="tech-label">Notification Service</div>
+                    <div className="tech-status">
+                      <span className={`status-dot ${wsConnected ? 'online' : ''}`} />
+                      {wsConnected ? 'Connected (WebSocket)' : 'Connecting...'}
+                    </div>
+                  </div>
+                  <div className="tech-item">
+                    <div className="tech-label">Stellar RPC (Soroban)</div>
+                    <div className="tech-status">
+                      <span className="status-dot online" />
+                      Mainnet - 🚀 Horizon
+                    </div>
+                  </div>
                 </div>
-              )}
-              </MotionCard>
-            </motion.div>
-          </GlassPanel>
+              </div>
 
-          {/* Right Panel - Chat Agent */}
-          <GlassPanel className="dashboard-chat" variants={itemVariants}>
-            {messages.length === 0 && !isTyping ? (
-              <EmptyState
-                title="No messages yet"
-                message="Ask Smasage to help manage your portfolio or set a goal."
-              />
-            ) : (
-              <ChatInterface
-                messages={messages}
-                isTyping={isTyping}
-                onSendMessage={handleSendMessage}
-                isConnected={wsConnected}
-              />
-            )}
-          </GlassPanel>
-        </motion.main>
-      </>
+              <div className="tech-section">
+                <h3 className="tech-section-title">
+                  <ShieldCheck size={14} /> Wallet & Security
+                </h3>
+                <div className="tech-grid">
+                  <div className="tech-item">
+                    <div className="tech-label">Public Key</div>
+                    <div className="tech-value">{publicKey || 'Not connected'}</div>
+                  </div>
+                  <div className="tech-item">
+                    <div className="tech-label">Provider</div>
+                    <div className="tech-value">Freighter Wallet</div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="tech-section">
+                <h3 className="tech-section-title">
+                  <Cpu size={14} /> AI Context
+                </h3>
+                <div className="tech-grid">
+                  <div className="tech-item">
+                    <div className="tech-label">Active Model</div>
+                    <div className="tech-value">OpenClaw (Gemini 1.5 Pro)</div>
+                  </div>
+                  <div className="tech-item">
+                    <div className="tech-label">Knowledge Cutoff</div>
+                    <div className="tech-value">May 2024</div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="tech-section">
+                <h3 className="tech-section-title">
+                  <Zap size={14} /> Protocol Routing
+                </h3>
+                <div className="tech-grid">
+                  <div className="tech-item">
+                    <div className="tech-label">Primary Aggregator</div>
+                    <div className="tech-value">Smasage V1</div>
+                  </div>
+                  <div className="tech-item">
+                    <div className="tech-label">Supported Protocols</div>
+                    <div className="tech-value">Blend, Soroswap, Aquarius</div>
+                  </div>
+                </div>
+              </div>
+            </Drawer>
+
+            <WalletModalTest
+              isOpen={showInstallModal}
+              onClose={() => setShowInstallModal(false)}
+            />
+          </>
+        }
+      >
+        <BentoDashboard
+          metrics={metricsSlot}
+          goalProgress={goalSlot}
+          chart={chartSlot}
+          wallet={walletSlot}
+          status={statusSlot}
+          agent={agentSlot}
+        />
+      </DashboardLayout>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/components/features/dashboard/BentoDashboard.tsx
+++ b/frontend/src/components/features/dashboard/BentoDashboard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { makeContainerVariants, makeEntranceVariants } from '../../../lib/motion';
+
+export interface BentoDashboardProps {
+  metrics: React.ReactNode;
+  goalProgress: React.ReactNode;
+  chart: React.ReactNode;
+  agent: React.ReactNode;
+  wallet?: React.ReactNode;
+  status?: React.ReactNode;
+}
+
+export function BentoDashboard({
+  metrics,
+  goalProgress,
+  chart,
+  agent,
+  wallet,
+  status,
+}: BentoDashboardProps) {
+  const prefersReduced = useReducedMotion();
+  const containerVariants = makeContainerVariants(!!prefersReduced);
+  const itemVariants = makeEntranceVariants(!!prefersReduced);
+
+  return (
+    <motion.div
+      className="bento-grid"
+      aria-label="Portfolio dashboard"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
+      <motion.div className="bento-area-metrics" variants={itemVariants}>
+        {metrics}
+      </motion.div>
+
+      <motion.div className="bento-area-goal" variants={itemVariants}>
+        {goalProgress}
+      </motion.div>
+
+      <motion.div className="bento-area-chart" variants={itemVariants}>
+        {chart}
+      </motion.div>
+
+      {wallet && (
+        <motion.div className="bento-area-wallet" variants={itemVariants}>
+          {wallet}
+        </motion.div>
+      )}
+
+      {status && (
+        <motion.div className="bento-area-status" variants={itemVariants}>
+          {status}
+        </motion.div>
+      )}
+
+      <motion.div className="bento-area-agent" variants={itemVariants}>
+        {agent}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/features/dashboard/index.ts
+++ b/frontend/src/components/features/dashboard/index.ts
@@ -1,0 +1,1 @@
+export * from './BentoDashboard';

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface DashboardLayoutProps {
+  header: React.ReactNode;
+  children: React.ReactNode;
+  overlays?: React.ReactNode;
+}
+
+export function DashboardLayout({ header, children, overlays }: DashboardLayoutProps) {
+  return (
+    <div className="dashboard-layout">
+      {header}
+      {overlays}
+      <main className="dashboard-layout-main">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export * from './DashboardHeader';
 export * from './GlassPanel';
 export * from './WsStatusIndicator';
+export * from './DashboardLayout';

--- a/frontend/src/components/primitives/Modal.tsx
+++ b/frontend/src/components/primitives/Modal.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import React, { useEffect, useRef, useId } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { X } from 'lucide-react';
+import { cardSpring } from '../../lib/motion';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+export function Modal({ isOpen, onClose, title, children, actions }: ModalProps) {
+  const titleId = useId();
+  const bodyId = useId();
+  const prefersReduced = useReducedMotion();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab' || !contentRef.current) return;
+
+      const focusable = Array.from(
+        contentRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    requestAnimationFrame(() => {
+      const first = contentRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      first?.focus();
+    });
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+      previousFocusRef.current?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  const contentVariants = prefersReduced
+    ? { hidden: { opacity: 0 }, visible: { opacity: 1 } }
+    : { hidden: { opacity: 0, y: 20, scale: 0.96 }, visible: { opacity: 1, y: 0, scale: 1 } };
+
+  const contentTransition = prefersReduced
+    ? { duration: 0.12 }
+    : { ...cardSpring };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="modal-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: prefersReduced ? 0.1 : 0.2 }}
+          onClick={onClose}
+          role="presentation"
+        >
+          <motion.div
+            ref={contentRef}
+            className="modal-content"
+            variants={contentVariants}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            transition={contentTransition}
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={bodyId}
+          >
+            <button
+              className="modal-close-icon"
+              onClick={onClose}
+              aria-label="Close dialog"
+            >
+              <X size={20} aria-hidden="true" />
+            </button>
+
+            <h2 id={titleId} className="modal-title">{title}</h2>
+
+            <div id={bodyId} className="modal-body">
+              {children}
+            </div>
+
+            {actions && (
+              <div className="modal-actions">{actions}</div>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/primitives/Tooltip.tsx
+++ b/frontend/src/components/primitives/Tooltip.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { useState, useId } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactElement;
+  placement?: TooltipPlacement;
+}
+
+export function Tooltip({ content, children, placement = 'top' }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const prefersReduced = useReducedMotion();
+  const tooltipId = useId();
+
+  const show = () => setVisible(true);
+  const hide = () => setVisible(false);
+
+  const {
+    onMouseEnter: origMouseEnter,
+    onMouseLeave: origMouseLeave,
+    onFocus: origFocus,
+    onBlur: origBlur,
+  } = children.props as React.HTMLAttributes<HTMLElement>;
+
+  const trigger = React.cloneElement(children, {
+    'aria-describedby': visible ? tooltipId : undefined,
+    onMouseEnter: (e: React.MouseEvent<HTMLElement>) => { origMouseEnter?.(e); show(); },
+    onMouseLeave: (e: React.MouseEvent<HTMLElement>) => { origMouseLeave?.(e); hide(); },
+    onFocus: (e: React.FocusEvent<HTMLElement>) => { origFocus?.(e); show(); },
+    onBlur: (e: React.FocusEvent<HTMLElement>) => { origBlur?.(e); hide(); },
+  });
+
+  const transition = { duration: prefersReduced ? 0.08 : 0.12, ease: 'easeOut' as const };
+
+  return (
+    <div className="tooltip-wrapper">
+      {trigger}
+      <AnimatePresence>
+        {visible && (
+          <div className={`tooltip-anchor tooltip-${placement}`}>
+            <motion.div
+              id={tooltipId}
+              role="tooltip"
+              className="tooltip-content"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={transition}
+            >
+              {content}
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/components/primitives/index.ts
+++ b/frontend/src/components/primitives/index.ts
@@ -5,3 +5,7 @@ export type { StatusPillProps, StatusVariant } from './StatusPill';
 export { MetricTile } from './MetricTile';
 export type { MetricTileProps, TrendDirection } from './MetricTile';
 export { MotionCard } from './MotionCard';
+export { Modal } from './Modal';
+export type { ModalProps } from './Modal';
+export { Tooltip } from './Tooltip';
+export type { TooltipProps, TooltipPlacement } from './Tooltip';


### PR DESCRIPTION
 Summary
  
  Resolves four Frontend Revamp audit items for the Smasage dashboard UI.

  Changes

  - feat(primitives): Modal — Generic typed modal with Framer Motion AnimatePresence enter/exit, manual focus
  trap, Escape + backdrop close, body scroll lock, and automatic focus restoration to the opener (#77)
  - feat(primitives): Tooltip — Frosted-glass contextual tooltip supporting keyboard (focus/blur) and pointer
  (hover) users; no layout shift; strictly typed props; reduced-motion aware (#78)
  - feat(layout): DashboardLayout — Reusable page shell exposing header, children, and overlays slots; max-width
  containment; responsive padding from 375 px to 1520 px (#79)
  - feat(dashboard): BentoDashboard — CSS grid bento layout with named areas (metrics, goal, chart, wallet,
  status, agent); responsive reflow (3-col → 2-col → single-column); replaces previous two-panel structure;
  stagger animation via existing makeContainerVariants (#80)

Closes #77
Closes #78
Closes #79
Closes #80